### PR TITLE
Integrate storage worker and new storage node

### DIFF
--- a/common-lib/src/main/java/com/github/koop/common/Util.java
+++ b/common-lib/src/main/java/com/github/koop/common/Util.java
@@ -2,6 +2,6 @@ package com.github.koop.common;
 
 public class Util {
     public static String buildObjectKey(String bucket, String object) {
-        return bucket + "/" + object;
+        return bucket + "-" + object;
     }
 }

--- a/common-lib/src/main/java/com/github/koop/common/Util.java
+++ b/common-lib/src/main/java/com/github/koop/common/Util.java
@@ -1,0 +1,7 @@
+package com.github.koop.common;
+
+public class Util {
+    public static String buildObjectKey(String bucket, String object) {
+        return bucket + "/" + object;
+    }
+}

--- a/common-lib/src/main/java/com/github/koop/common/Util.java
+++ b/common-lib/src/main/java/com/github/koop/common/Util.java
@@ -1,7 +1,0 @@
-package com.github.koop.common;
-
-public class Util {
-    public static String buildObjectKey(String bucket, String object) {
-        return bucket + "-" + object;
-    }
-}

--- a/common-lib/src/main/java/com/github/koop/common/metadata/MetadataClient.java
+++ b/common-lib/src/main/java/com/github/koop/common/metadata/MetadataClient.java
@@ -48,6 +48,10 @@ public class MetadataClient implements AutoCloseable {
         });
     }
 
+    public <T> T get(Class<T> clazz) {
+        return clazz.cast(cache.get(clazz));
+    }
+
     @Override
     public void close() throws Exception {
         fetcher.close();

--- a/common-lib/src/main/java/com/github/koop/common/metadata/MetadataClient.java
+++ b/common-lib/src/main/java/com/github/koop/common/metadata/MetadataClient.java
@@ -14,7 +14,8 @@ public class MetadataClient implements AutoCloseable {
     private final Map<Class<?>, List<ChangeListener<?>>> listeners = new ConcurrentHashMap<>();
 
     private final static Logger logger = LogManager.getLogger(MetadataClient.class);
-
+    private boolean started = false;
+    private boolean closed = false;
     public MetadataClient(Fetcher fetcher) {
         this.fetcher = fetcher;
     }
@@ -31,6 +32,12 @@ public class MetadataClient implements AutoCloseable {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void start() {
+        if(started) {
+            throw new IllegalStateException("MetadataClient has already been started");
+        }
+        if(closed) {
+            throw new IllegalStateException("MetadataClient has already been closed");
+        }
         this.fetcher.start(newObj->{
             var clazz = newObj.getClass();
             var prev = cache.put(clazz, newObj);
@@ -46,6 +53,7 @@ public class MetadataClient implements AutoCloseable {
             }
             
         });
+        started = true;
     }
 
     public <T> T get(Class<T> clazz) {
@@ -54,7 +62,18 @@ public class MetadataClient implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
+        if(closed) {
+            throw new IllegalStateException("MetadataClient has already been closed");
+        }
+        closed = true;
         fetcher.close();
+    }
+
+    public boolean isStarted() {
+        return started;
+    }
+    public boolean isClosed() {
+        return closed;
     }
     
 }

--- a/common-lib/src/test/java/com/github/koop/common/metadata/MetadataClientTest.java
+++ b/common-lib/src/test/java/com/github/koop/common/metadata/MetadataClientTest.java
@@ -33,7 +33,9 @@ class MetadataClientTest {
 
     @AfterEach
     void tearDown() throws Exception {
-        metadataClient.close();
+        if(!metadataClient.isClosed()) {
+            metadataClient.close();
+        }
     }
 
     @Test

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -166,7 +166,7 @@ public final class StorageWorker {
         if (data == null)      throw new IllegalArgumentException("data is null");
         if (length < 0)        throw new IllegalArgumentException("length < 0");
 
-        String storageKey = Util.buildObjectKey(bucket, key);
+        String storageKey = bucket+"/"+key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -249,7 +249,7 @@ public final class StorageWorker {
         if (bucket == null)    throw new IllegalArgumentException("bucket is null");
         if (key == null)       throw new IllegalArgumentException("key is null");
 
-        String storageKey = Util.buildObjectKey(bucket, key);
+        String storageKey = bucket+"/"+key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -281,7 +281,7 @@ public final class StorageWorker {
         if (bucket == null)    throw new IllegalArgumentException("bucket is null");
         if (key == null)       throw new IllegalArgumentException("key is null");
 
-        String storageKey = Util.buildObjectKey(bucket, key);
+        String storageKey = bucket+"/"+key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -60,7 +60,8 @@ public final class StorageWorker {
 
     // FOR TESTING ONLY - builds a MetadataClient backed by a MemoryFetcher and
     // pre-populates it with an ErasureSetConfiguration derived from the three
-    // address lists (set numbers 1, 2, 3) and a matching PartitionSpreadConfiguration
+    // address lists (set numbers 1, 2, 3) and a matching
+    // PartitionSpreadConfiguration
     // with 99 partitions spread evenly across the three sets (33 each).
     public StorageWorker(List<InetSocketAddress> set1, List<InetSocketAddress> set2, List<InetSocketAddress> set3) {
         this(set1, set2, set3, 0);
@@ -69,7 +70,7 @@ public final class StorageWorker {
     // Overload that accepts a pre-built CommitCoordinator — used in tests that
     // share a PubSubClient bus between the coordinator and the fake SNs.
     public StorageWorker(List<InetSocketAddress> set1, List<InetSocketAddress> set2,
-                         List<InetSocketAddress> set3, CommitCoordinator commitCoordinator) {
+            List<InetSocketAddress> set3, CommitCoordinator commitCoordinator) {
         this.executor = Executors.newVirtualThreadPerTaskExecutor();
         this.httpClient = HttpClient.newBuilder()
                 .executor(Executors.newVirtualThreadPerTaskExecutor())
@@ -88,7 +89,8 @@ public final class StorageWorker {
         fetcher.update(buildTestPartitionSpread());
     }
 
-    public StorageWorker(List<InetSocketAddress> set1, List<InetSocketAddress> set2, List<InetSocketAddress> set3, int ackPort) {
+    public StorageWorker(List<InetSocketAddress> set1, List<InetSocketAddress> set2, List<InetSocketAddress> set3,
+            int ackPort) {
         this.executor = Executors.newVirtualThreadPerTaskExecutor();
         this.httpClient = HttpClient.newBuilder()
                 .executor(Executors.newVirtualThreadPerTaskExecutor())
@@ -150,23 +152,29 @@ public final class StorageWorker {
     /**
      * Executes a full PUT:
      * <ol>
-     *   <li>Erasure-code and stream shards to all {@value com.github.koop.common.erasure.ErasureCoder#TOTAL}
-     *       storage nodes concurrently.</li>
-     *   <li>Publish a commit message to the per-partition Kafka topic so every SN
-     *       applies the operation to its op-log and metadata. SNs that missed the
-     *       stream reconstruct their shard from peers before committing.</li>
-     *   <li>Block until {@link CommitCoordinator#QUORUM} SN commit-ACKs are received,
-     *       then return {@code true} to the caller.</li>
+     * <li>Erasure-code and stream shards to all
+     * {@value com.github.koop.common.erasure.ErasureCoder#TOTAL}
+     * storage nodes concurrently.</li>
+     * <li>Publish a commit message to the per-partition Kafka topic so every SN
+     * applies the operation to its op-log and metadata. SNs that missed the
+     * stream reconstruct their shard from peers before committing.</li>
+     * <li>Block until {@link CommitCoordinator#QUORUM} SN commit-ACKs are received,
+     * then return {@code true} to the caller.</li>
      * </ol>
      */
     public boolean put(UUID requestID, String bucket, String key, long length, InputStream data) throws IOException {
-        if (requestID == null) throw new IllegalArgumentException("requestID is null");
-        if (bucket == null)    throw new IllegalArgumentException("bucket is null");
-        if (key == null)       throw new IllegalArgumentException("key is null");
-        if (data == null)      throw new IllegalArgumentException("data is null");
-        if (length < 0)        throw new IllegalArgumentException("length < 0");
+        if (requestID == null)
+            throw new IllegalArgumentException("requestID is null");
+        if (bucket == null)
+            throw new IllegalArgumentException("bucket is null");
+        if (key == null)
+            throw new IllegalArgumentException("key is null");
+        if (data == null)
+            throw new IllegalArgumentException("data is null");
+        if (length < 0)
+            throw new IllegalArgumentException("length < 0");
 
-        String storageKey = bucket+"/"+key;
+        String storageKey = bucket + "/" + key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -201,8 +209,7 @@ public final class StorageWorker {
                             .PUT(HttpRequest.BodyPublishers.ofInputStream(() -> shardStreams[index]))
                             .header("Content-Type", "application/octet-stream")
                             .build();
-                    HttpResponse<String> response =
-                            httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
                     if (response.statusCode() == 200) {
                         logger.trace("PUT shard {} → node {} succeeded", index, node);
                         return true;
@@ -218,8 +225,9 @@ public final class StorageWorker {
         long uploaded;
         try {
             uploaded = executor.invokeAll(tasks).stream().filter(f -> {
-                try { return f.get(); }
-                catch (InterruptedException | ExecutionException e) {
+                try {
+                    return f.get();
+                } catch (InterruptedException | ExecutionException e) {
                     logger.warn("Shard upload task error: {}", e.getMessage());
                     return false;
                 }
@@ -229,13 +237,18 @@ public final class StorageWorker {
             return false;
         }
 
+        if (uploaded < CommitCoordinator.QUORUM) {
+            logger.error("Phase 1 failed: only {}/{} shards uploaded. Aborting commit.", uploaded, TOTAL);
+            return false;
+        }
+
         logger.debug("Phase 1 complete: {}/{} shards uploaded for requestId {}", uploaded, TOTAL, requestID);
 
         // Phase 2 – commit.
         //
         // Publish the commit message to the partition's Kafka topic. Every SN will:
-        //   - add the op to its op-log + write metadata, if it received the shard; or
-        //   - reconstruct the shard from peers and then commit, if it didn't.
+        // - add the op to its op-log + write metadata, if it received the shard; or
+        // - reconstruct the shard from peers and then commit, if it didn't.
         // SNs POST an ACK back to this QP's server. We block until QUORUM ACKs arrive.
         boolean committed = commitCoordinator.beginCommit(requestID, resolvedPartition, bucket, key);
         if (!committed) {
@@ -245,11 +258,14 @@ public final class StorageWorker {
     }
 
     public InputStream get(UUID requestID, String bucket, String key) throws IOException {
-        if (requestID == null) throw new IllegalArgumentException("requestID is null");
-        if (bucket == null)    throw new IllegalArgumentException("bucket is null");
-        if (key == null)       throw new IllegalArgumentException("key is null");
+        if (requestID == null)
+            throw new IllegalArgumentException("requestID is null");
+        if (bucket == null)
+            throw new IllegalArgumentException("bucket is null");
+        if (key == null)
+            throw new IllegalArgumentException("key is null");
 
-        String storageKey = bucket+"/"+key;
+        String storageKey = bucket + "/" + key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -269,7 +285,11 @@ public final class StorageWorker {
             try (pos) {
                 streamReconstruct(resolvedPartition, storageKey, resolvedNodes, pos);
             } catch (Exception e) {
-                try { pos.close(); } catch (IOException ignored) {}
+                logger.error("Failed to reconstruct stream for key {}", storageKey, e);
+                try {
+                    pos.close();
+                } catch (IOException ignored) {
+                }
             }
         });
 
@@ -277,11 +297,14 @@ public final class StorageWorker {
     }
 
     public boolean delete(UUID requestID, String bucket, String key) throws IOException {
-        if (requestID == null) throw new IllegalArgumentException("requestID is null");
-        if (bucket == null)    throw new IllegalArgumentException("bucket is null");
-        if (key == null)       throw new IllegalArgumentException("key is null");
+        if (requestID == null)
+            throw new IllegalArgumentException("requestID is null");
+        if (bucket == null)
+            throw new IllegalArgumentException("bucket is null");
+        if (key == null)
+            throw new IllegalArgumentException("key is null");
 
-        String storageKey = bucket+"/"+key;
+        String storageKey = bucket + "/" + key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -374,7 +397,7 @@ public final class StorageWorker {
         if (ps != null && es != null) {
             routing.set(new ErasureRouting(ps, es));
             logger.info("ErasureRouting rebuilt");
-        }else {
+        } else {
             logger.info("Cannot rebuild ErasureRouting yet (waiting for both configs): "
                     + "PartitionSpreadConfiguration is {}, ErasureSetConfiguration is {}",
                     ps == null ? "null" : "present", es == null ? "null" : "present");
@@ -394,7 +417,7 @@ public final class StorageWorker {
     }
 
     private void streamReconstruct(int partition, String storageKey,
-                                   List<InetSocketAddress> nodes, OutputStream out) throws IOException {
+            List<InetSocketAddress> nodes, OutputStream out) throws IOException {
 
         InputStream[] ins = new InputStream[TOTAL];
         boolean[] present = new boolean[TOTAL];
@@ -420,21 +443,25 @@ public final class StorageWorker {
         }
 
         int count = 0;
-        for (boolean b : present) if (b) count++;
+        for (boolean b : present)
+            if (b)
+                count++;
         if (count < ErasureCoder.K)
             throw new IOException("lost too many shards; need " + ErasureCoder.K + ", got " + count);
 
         try (InputStream reconstructed = ErasureCoder.reconstruct(ins, present)) {
             byte[] buf = new byte[64 * 1024];
             int n;
-            while ((n = reconstructed.read(buf)) != -1) out.write(buf, 0, n);
+            while ((n = reconstructed.read(buf)) != -1)
+                out.write(buf, 0, n);
         }
         out.flush();
     }
 
     /**
      * FOR TESTING ONLY - builds a PartitionSpreadConfiguration with 99 partitions
-     * spread evenly: partitions 0-32 → erasure set 1, 33-65 → erasure set 2, 66-98 → erasure set 3.
+     * spread evenly: partitions 0-32 → erasure set 1, 33-65 → erasure set 2, 66-98
+     * → erasure set 3.
      */
     private static PartitionSpreadConfiguration buildTestPartitionSpread() {
         PartitionSpreadConfiguration ps = new PartitionSpreadConfiguration();
@@ -443,7 +470,8 @@ public final class StorageWorker {
             PartitionSpread spread = new PartitionSpread();
             spread.setErasureSet(s + 1); // set numbers 1, 2, 3
             List<Integer> partitions = new ArrayList<>();
-            for (int p = s * 33; p < (s + 1) * 33; p++) partitions.add(p);
+            for (int p = s * 33; p < (s + 1) * 33; p++)
+                partitions.add(p);
             spread.setPartitions(partitions);
             spreads.add(spread);
         }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -1,5 +1,6 @@
 package com.github.koop.queryprocessor.processor;
 
+import com.github.koop.common.Util;
 import com.github.koop.common.erasure.ErasureCoder;
 import com.github.koop.common.metadata.ErasureSetConfiguration;
 import com.github.koop.common.metadata.ErasureSetConfiguration.ErasureSet;
@@ -165,7 +166,7 @@ public final class StorageWorker {
         if (data == null)      throw new IllegalArgumentException("data is null");
         if (length < 0)        throw new IllegalArgumentException("length < 0");
 
-        String storageKey = bucket + "-" + key;
+        String storageKey = Util.buildObjectKey(bucket, key);
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -248,7 +249,7 @@ public final class StorageWorker {
         if (bucket == null)    throw new IllegalArgumentException("bucket is null");
         if (key == null)       throw new IllegalArgumentException("key is null");
 
-        String storageKey = bucket + "-" + key;
+        String storageKey = Util.buildObjectKey(bucket, key);
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()
@@ -280,7 +281,7 @@ public final class StorageWorker {
         if (bucket == null)    throw new IllegalArgumentException("bucket is null");
         if (key == null)       throw new IllegalArgumentException("key is null");
 
-        String storageKey = bucket + "-" + key;
+        String storageKey = Util.buildObjectKey(bucket, key);
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
         Optional<List<InetSocketAddress>> nodes = partition.isPresent()

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -1,6 +1,5 @@
 package com.github.koop.queryprocessor.processor;
 
-import com.github.koop.common.Util;
 import com.github.koop.common.erasure.ErasureCoder;
 import com.github.koop.common.metadata.ErasureSetConfiguration;
 import com.github.koop.common.metadata.ErasureSetConfiguration.ErasureSet;

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -129,7 +129,7 @@ public final class StorageWorker {
         this.metadataClient = metadataClient;
         this.commitCoordinator = commitCoordinator;
         registerListeners();
-        this.metadataClient.start();
+        tryRebuildRouting();
     }
 
     private static CommitCoordinator buildDefaultCommitCoordinator() {

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -49,8 +49,6 @@ public final class StorageWorker {
     private final HttpClient httpClient;
     private final MetadataClient metadataClient;
     private final CommitCoordinator commitCoordinator;
-    private final AtomicReference<ErasureSetConfiguration> erasureSetConfig = new AtomicReference<>();
-    private final AtomicReference<PartitionSpreadConfiguration> partitionSpreadConfig = new AtomicReference<>();
     private final AtomicReference<ErasureRouting> routing = new AtomicReference<>();
 
     // FOR TESTING ONLY - constructs a MetadataClient backed by a MemoryFetcher
@@ -352,16 +350,14 @@ public final class StorageWorker {
 
     private void registerListeners() {
         this.metadataClient.listen(ErasureSetConfiguration.class, (prev, current) -> {
-            erasureSetConfig.set(current);
             logger.info("ErasureSetConfiguration updated: {} erasure sets",
                     current.getErasureSets() == null ? 0 : current.getErasureSets().size());
-            tryRebuildRouting(partitionSpreadConfig.get(), current);
+            tryRebuildRouting();
         });
         this.metadataClient.listen(PartitionSpreadConfiguration.class, (prev, current) -> {
-            partitionSpreadConfig.set(current);
             logger.info("PartitionSpreadConfiguration updated: {} spread entries",
                     current.getPartitionSpread() == null ? 0 : current.getPartitionSpread().size());
-            tryRebuildRouting(current, erasureSetConfig.get());
+            tryRebuildRouting();
         });
     }
 
@@ -371,10 +367,16 @@ public final class StorageWorker {
      * if one hasn't arrived yet this is a no-op and the first update of the
      * lagging config will trigger the rebuild instead.
      */
-    private void tryRebuildRouting(PartitionSpreadConfiguration ps, ErasureSetConfiguration es) {
+    private void tryRebuildRouting() {
+        PartitionSpreadConfiguration ps = metadataClient.get(PartitionSpreadConfiguration.class);
+        ErasureSetConfiguration es = metadataClient.get(ErasureSetConfiguration.class);
         if (ps != null && es != null) {
             routing.set(new ErasureRouting(ps, es));
             logger.info("ErasureRouting rebuilt");
+        }else {
+            logger.info("Cannot rebuild ErasureRouting yet (waiting for both configs): "
+                    + "PartitionSpreadConfiguration is {}, ErasureSetConfiguration is {}",
+                    ps == null ? "null" : "present", es == null ? "null" : "present");
         }
     }
 

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/FakeStorageNodeServer.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/FakeStorageNodeServer.java
@@ -12,10 +12,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-/**
- * Fake storage node HTTP server for testing.
- * Mimics the real StorageNodeServer Javalin endpoints.
- */
 public class FakeStorageNodeServer implements Closeable {
 
     private final Javalin app;
@@ -28,14 +24,14 @@ public class FakeStorageNodeServer implements Closeable {
         app = Javalin.create(config -> {
             config.concurrency.useVirtualThreads = true;
             config.startup.showJavalinBanner = false;
-            config.http.maxRequestSize = 100_000_000L; // 100 MB — tests use large payloads
+            config.http.maxRequestSize = 100_000_000L;
 
-            config.routes.put("/store/{partition}/{key}", this::handlePut);
-            config.routes.get("/store/{partition}/{key}", this::handleGet);
-            config.routes.delete("/store/{partition}/{key}", this::handleDelete);
+            config.routes.put("/store/{partition}/{bucket}/<key>", this::handlePut);
+            config.routes.get("/store/{partition}/{bucket}/<key>", this::handleGet);
+            config.routes.delete("/store/{partition}/{bucket}/<key>", this::handleDelete);
         });
 
-        app.start(0); // OS picks a free port
+        app.start(0);
     }
 
     public InetSocketAddress address() {
@@ -53,10 +49,12 @@ public class FakeStorageNodeServer implements Closeable {
         }
         try {
             int partition = Integer.parseInt(ctx.pathParam("partition"));
-            String key    = ctx.pathParam("key");
+            String bucket = ctx.pathParam("bucket");
+            String key    = ctx.pathParam("key"); 
+            String fullKey = bucket + "/" + key;
             byte[] data   = ctx.bodyAsBytes();
 
-            store.put(mapKey(partition, key), data);
+            store.put(mapKey(partition, fullKey), data);
             ctx.status(200).result("OK");
         } catch (Exception e) {
             logger.error("Error in fake PUT", e);
@@ -71,9 +69,11 @@ public class FakeStorageNodeServer implements Closeable {
         }
         try {
             int partition = Integer.parseInt(ctx.pathParam("partition"));
+            String bucket = ctx.pathParam("bucket");
             String key    = ctx.pathParam("key");
+            String fullKey = bucket + "/" + key;
 
-            byte[] data = store.get(mapKey(partition, key));
+            byte[] data = store.get(mapKey(partition, fullKey));
             if (data != null) {
                 ctx.status(200)
                    .header("Content-Type", "application/octet-stream")
@@ -94,9 +94,11 @@ public class FakeStorageNodeServer implements Closeable {
         }
         try {
             int partition = Integer.parseInt(ctx.pathParam("partition"));
+            String bucket = ctx.pathParam("bucket");
             String key    = ctx.pathParam("key");
+            String fullKey = bucket + "/" + key;
 
-            store.remove(mapKey(partition, key));
+            store.remove(mapKey(partition, fullKey));
             ctx.status(200).result("OK");
         } catch (Exception e) {
             logger.error("Error in fake DELETE", e);
@@ -104,8 +106,8 @@ public class FakeStorageNodeServer implements Closeable {
         }
     }
 
-    private static String mapKey(int partition, String key) {
-        return partition + "|" + key;
+    private static String mapKey(int partition, String fullKey) {
+        return partition + "|" + fullKey;
     }
 
     @Override

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
@@ -154,7 +154,8 @@ public class StorageWorkerApiTest {
         try {
             List<InetSocketAddress> newSet = newNodes.stream()
                     .map(AckingFakeStorageNodeServer::address).toList();
-
+            var metadataClient = new MetadataClient(memoryFetcher);
+            metadataClient.start();
             memoryFetcher.update(buildErasureSetConfiguration(newSet, newSet, newSet));
             memoryFetcher.update(buildPartitionSpreadConfiguration());
 
@@ -163,7 +164,7 @@ public class StorageWorkerApiTest {
             // the old one is subscribed to the old sharedPubSub.
             CommitCoordinator freshCoordinator = new CommitCoordinator(sharedPubSub, 0);
             StorageWorker freshLiveWorker = new StorageWorker(
-                    new MetadataClient(memoryFetcher), freshCoordinator);
+                    metadataClient, freshCoordinator);
             memoryFetcher.update(buildErasureSetConfiguration(newSet, newSet, newSet));
             memoryFetcher.update(buildPartitionSpreadConfiguration());
 
@@ -195,6 +196,7 @@ public class StorageWorkerApiTest {
 
             MemoryFetcher fetcher = new MemoryFetcher();
             MetadataClient client = new MetadataClient(fetcher);
+            client.start();
             CommitCoordinator coordinator = new CommitCoordinator(sharedPubSub, 0);
             StorageWorker prodWorker = new StorageWorker(client, coordinator);
             fetcher.update(buildErasureSetConfiguration(set, set, set));

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.koop.common.Util;
 import com.github.koop.common.messages.Message;
 import com.github.koop.common.metadata.ErasureSetConfiguration;
 import com.github.koop.common.metadata.MetadataClient;
@@ -371,7 +372,7 @@ private void sendAck(String callbackAddress, String requestId) {
     private String buildKey(String bucket, String key) {
         if (bucket == null || bucket.isEmpty())
             return key;
-        return bucket + "/" + key;
+        return Util.buildObjectKey(bucket, key);
     }
 
     // --- Server Lifecycle ---

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -378,6 +378,8 @@ private void sendAck(String callbackAddress, String requestId) {
 
     public void start() {
         if (metadataClient != null) {
+            this.currentEsConfig = metadataClient.get(ErasureSetConfiguration.class);
+            this.currentPsConfig = metadataClient.get(PartitionSpreadConfiguration.class);
             metadataClient.listen(ErasureSetConfiguration.class, (prev, current) -> {
                 this.currentEsConfig = current;
                 updateSubscriptions();
@@ -387,12 +389,6 @@ private void sendAck(String callbackAddress, String requestId) {
                 this.currentPsConfig = current;
                 updateSubscriptions();
             });
-
-            metadataClient.start();
-        }
-
-        if (pubSubClient != null) {
-            pubSubClient.start();
         }
 
         app = Javalin.create(config -> {

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -364,8 +364,10 @@ public class StorageNodeServerV2 {
 
     public void start() {
         if (metadataClient != null) {
-            this.currentEsConfig=metadataClient.get(ErasureSetConfiguration.class);
-            this.currentPsConfig=metadataClient.get(PartitionSpreadConfiguration.class);
+            this.currentEsConfig = metadataClient.get(ErasureSetConfiguration.class);
+            this.currentPsConfig = metadataClient.get(PartitionSpreadConfiguration.class);
+            updateSubscriptions();
+
             metadataClient.listen(ErasureSetConfiguration.class, (prev, current) -> {
                 this.currentEsConfig = current;
                 updateSubscriptions();

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -20,8 +20,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.koop.common.Util;
 import com.github.koop.common.messages.Message;
 import com.github.koop.common.metadata.ErasureSetConfiguration;
 import com.github.koop.common.metadata.MetadataClient;
@@ -32,11 +30,6 @@ import com.github.koop.storagenode.db.Database;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 
-/**
- * Storage Node HTTP server powered by Javalin + virtual threads.
- * Integrates MetadataClient and PubSubClient for dynamic partition assignment
- * and sequencer log tailing.
- */
 public class StorageNodeServerV2 {
 
     private final int port;
@@ -49,11 +42,9 @@ public class StorageNodeServerV2 {
     private ErasureSetConfiguration currentEsConfig;
     private PartitionSpreadConfiguration currentPsConfig;
 
-    // Tracks active partition subscriptions and their dedicated executors
     private final Set<Integer> subscribedPartitions = new HashSet<>();
     private final Map<Integer, ExecutorService> partitionExecutors = new ConcurrentHashMap<>();
 
-    // HTTP Client for sending asynchronous acknowledgments
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
             .build();
@@ -87,7 +78,6 @@ public class StorageNodeServerV2 {
             System.exit(1);
         }
 
-        // Injected dependencies
         Database db = null;
         MetadataClient metadataClient = null;
         PubSubClient pubSubClient = null;
@@ -101,8 +91,6 @@ public class StorageNodeServerV2 {
 
         server.start();
     }
-
-    // --- Dynamic Configuration & Subscriptions ---
 
     private synchronized void updateSubscriptions() {
         if (currentEsConfig == null || currentPsConfig == null) {
@@ -144,7 +132,6 @@ public class StorageNodeServerV2 {
             pubSubClient.drop(topic);
             subscribedPartitions.remove(partition);
 
-            // Shutdown the dedicated executor for this partition
             ExecutorService executor = partitionExecutors.remove(partition);
             if (executor != null) {
                 executor.shutdown();
@@ -166,7 +153,6 @@ public class StorageNodeServerV2 {
             String topic = "partition-" + partition;
             logger.info("Node assigned to partition {}. Subscribing to topic: {}", partition, topic);
 
-            // Create a single-threaded executor backed by a virtual thread for sequential processing
             ExecutorService partitionExecutor = Executors.newSingleThreadExecutor(
                     Thread.ofVirtual().name("partition-" + partition + "-").factory());
             partitionExecutors.put(partition, partitionExecutor);
@@ -187,12 +173,12 @@ public class StorageNodeServerV2 {
         }
     }
 
-    // --- HTTP Handlers ---
-
    private void handlePut(Context ctx) {
         try {
             int partition = Integer.parseInt(ctx.pathParam("partition"));
+            String bucket = ctx.pathParam("bucket");
             String key = ctx.pathParam("key");
+            String fullKey = bucket + "/" + key;
             String requestId = ctx.queryParam("requestId");
             long length = ctx.req().getContentLengthLong();
 
@@ -201,10 +187,10 @@ public class StorageNodeServerV2 {
                 return;
             }
 
-            storageNode.store(partition, key, requestId, Channels.newChannel(ctx.bodyInputStream()), length);
+            storageNode.store(partition, fullKey, requestId, Channels.newChannel(ctx.bodyInputStream()), length);
 
             ctx.status(200).result("OK");
-            logger.debug("PUT (Uncommitted) partition={} key={} requestId={}", partition, key, requestId);
+            logger.debug("PUT (Uncommitted) partition={} fullKey={} requestId={}", partition, fullKey, requestId);
         } catch (Exception e) {
             logger.error("Error handling PUT", e);
             ctx.status(500).result("ERROR");
@@ -215,8 +201,9 @@ public class StorageNodeServerV2 {
         try {
             logger.debug("Received GET request: {}", ctx.req().getRequestURI());
             int partition = Integer.parseInt(ctx.pathParam("partition"));
+            String bucket = ctx.pathParam("bucket");
             String key = ctx.pathParam("key");
-            key = key.replaceFirst("-", "/");
+            String fullKey = bucket + "/" + key;
 
             String versionParam = ctx.queryParam("version");
             long targetVersion = -1;
@@ -229,9 +216,9 @@ public class StorageNodeServerV2 {
                     return;
                 }
             }
-            logger.debug("GET partition={} key={} targetVersion={}", partition, key, targetVersion);
+            logger.debug("GET partition={} fullKey={} targetVersion={}", partition, fullKey, targetVersion);
 
-            Optional<StorageNodeV2.GetObjectResponse> dataOpt = storageNode.retrieve(key, targetVersion);
+            Optional<StorageNodeV2.GetObjectResponse> dataOpt = storageNode.retrieve(fullKey, targetVersion);
 
             if (dataOpt.isPresent()) {
                 StorageNodeV2.GetObjectResponse response = dataOpt.get();
@@ -257,39 +244,37 @@ public class StorageNodeServerV2 {
                         long transferred = fc.transferTo(position, size - position, outputChannel);
                         if (transferred <= 0) {
                             logger.warn(
-                                    "Zero-byte transfer when streaming file for partition={} key={} at position={} of {} bytes",
-                                    partition, key, position, size);
+                                    "Zero-byte transfer when streaming file for partition={} fullKey={} at position={} of {} bytes",
+                                    partition, fullKey, position, size);
                             break;
                         }
                         position += transferred;
                     }
                     fo.close();
-                    logger.debug("GET partition={} key={} version={} streamed {} bytes", partition, key,
+                    logger.debug("GET partition={} fullKey={} version={} streamed {} bytes", partition, fullKey,
                             responseSequenceNumber, size);
 
                 } else if (response instanceof StorageNodeV2.MultipartData md) {
                     ctx.status(200)
                             .header("Content-Type", "application/json")
                             .json(md.version().chunks());
-                    logger.debug("GET partition={} key={} version={} returned multipart chunk list", partition, key,
+                    logger.debug("GET partition={} fullKey={} version={} returned multipart chunk list", partition, fullKey,
                             responseSequenceNumber);
 
                 } else if (response instanceof StorageNodeV2.Tombstone) {
                     ctx.status(404).result("NOT_FOUND (Tombstone)");
-                    logger.debug("GET partition={} key={} version={} hit tombstone", partition, key,
+                    logger.debug("GET partition={} fullKey={} version={} hit tombstone", partition, fullKey,
                             responseSequenceNumber);
                 }
             } else {
                 ctx.status(404).result("NOT_FOUND");
-                logger.debug("GET partition={} key={} targetVersion={} not found", partition, key, targetVersion);
+                logger.debug("GET partition={} fullKey={} targetVersion={} not found", partition, fullKey, targetVersion);
             }
         } catch (Exception e) {
             logger.error("Error handling GET", e);
             ctx.status(500).result("ERROR");
         }
     }
-
-    // --- Pub/Sub Mutator Flow ---
 
     public void processSequencerMessage(int partition, Message message, long seqNumber) {
         try {
@@ -329,7 +314,6 @@ public class StorageNodeServerV2 {
                 }
             }
 
-            // Fire and forget acknowledgment
             sendAck(callbackAddress, requestId);
 
         } catch (Exception e) {
@@ -337,20 +321,19 @@ public class StorageNodeServerV2 {
         }
     }
 
-private void sendAck(String callbackAddress, String requestId) {
+    private void sendAck(String callbackAddress, String requestId) {
         if (callbackAddress == null || callbackAddress.isBlank() || requestId == null || requestId.isBlank()) {
             return;
         }
 
         try {
-            // Standardize URL to use path parameters: http://host:port/ack/{requestId}
             String baseUrl = callbackAddress.endsWith("/") ? 
                     callbackAddress.substring(0, callbackAddress.length() - 1) : callbackAddress;
             String url = baseUrl + "/ack/" + requestId;
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
-                    .POST(HttpRequest.BodyPublishers.noBody()) // Simplest: Empty body
+                    .POST(HttpRequest.BodyPublishers.noBody())
                     .build();
 
             httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding())
@@ -370,18 +353,17 @@ private void sendAck(String callbackAddress, String requestId) {
             logger.error("Invalid callback URL format: {} for requestId: {}", callbackAddress, requestId, e);
         }
     }
+
     private String buildKey(String bucket, String key) {
         if (bucket == null || bucket.isEmpty())
             return key;
         return bucket + "/" + key;
     }
 
-    // --- Server Lifecycle ---
-
     public void start() {
         if (metadataClient != null) {
-            this.currentEsConfig = metadataClient.get(ErasureSetConfiguration.class);
-            this.currentPsConfig = metadataClient.get(PartitionSpreadConfiguration.class);
+            this.currentEsConfig=metadataClient.get(ErasureSetConfiguration.class);
+            this.currentPsConfig=metadataClient.get(PartitionSpreadConfiguration.class);
             metadataClient.listen(ErasureSetConfiguration.class, (prev, current) -> {
                 this.currentEsConfig = current;
                 updateSubscriptions();
@@ -397,8 +379,8 @@ private void sendAck(String callbackAddress, String requestId) {
             config.concurrency.useVirtualThreads = true;
             config.startup.showJavalinBanner = false;
             config.http.maxRequestSize = 100_000_000L;
-            config.routes.put("/store/{partition}/{key}", this::handlePut);
-            config.routes.get("/store/{partition}/{key}", this::handleGet);
+            config.routes.put("/store/{partition}/{bucket}/<key>", this::handlePut);
+            config.routes.get("/store/{partition}/{bucket}/<key>", this::handleGet);
         });
 
         app.start(port);
@@ -410,18 +392,6 @@ private void sendAck(String callbackAddress, String requestId) {
             app.stop();
         }
 
-        try {
-            if (metadataClient != null) {
-                metadataClient.close();
-            }
-            if (pubSubClient != null) {
-                pubSubClient.close();
-            }
-        } catch (Exception e) {
-            logger.error("Error shutting down clients", e);
-        }
-
-        // Clean up the partition executors
         partitionExecutors.values().forEach(ExecutorService::shutdownNow);
         partitionExecutors.clear();
 

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -216,6 +216,7 @@ public class StorageNodeServerV2 {
             logger.debug("Received GET request: {}", ctx.req().getRequestURI());
             int partition = Integer.parseInt(ctx.pathParam("partition"));
             String key = ctx.pathParam("key");
+            key = key.replaceFirst("-", "/");
 
             String versionParam = ctx.queryParam("version");
             long targetVersion = -1;
@@ -372,7 +373,7 @@ private void sendAck(String callbackAddress, String requestId) {
     private String buildKey(String bucket, String key) {
         if (bucket == null || bucket.isEmpty())
             return key;
-        return Util.buildObjectKey(bucket, key);
+        return bucket + "/" + key;
     }
 
     // --- Server Lifecycle ---

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -335,19 +335,20 @@ public class StorageNodeServerV2 {
         }
     }
 
-    private void sendAck(String callbackAddress, String requestId) {
+private void sendAck(String callbackAddress, String requestId) {
         if (callbackAddress == null || callbackAddress.isBlank() || requestId == null || requestId.isBlank()) {
             return;
         }
 
         try {
-            String url = callbackAddress.endsWith("/") ? callbackAddress + "ack" : callbackAddress + "/ack";
-            String jsonPayload = String.format("{\"requestId\":\"%s\"}", requestId);
+            // Standardize URL to use path parameters: http://host:port/ack/{requestId}
+            String baseUrl = callbackAddress.endsWith("/") ? 
+                    callbackAddress.substring(0, callbackAddress.length() - 1) : callbackAddress;
+            String url = baseUrl + "/ack/" + requestId;
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonPayload))
+                    .POST(HttpRequest.BodyPublishers.noBody()) // Simplest: Empty body
                     .build();
 
             httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding())
@@ -367,7 +368,6 @@ public class StorageNodeServerV2 {
             logger.error("Invalid callback URL format: {} for requestId: {}", callbackAddress, requestId, e);
         }
     }
-
     private String buildKey(String bucket, String key) {
         if (bucket == null || bucket.isEmpty())
             return key;

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -180,14 +180,16 @@ public class StorageNodeServerV2 {
             String key = ctx.pathParam("key");
             String fullKey = bucket + "/" + key;
             String requestId = ctx.queryParam("requestId");
-            long length = ctx.req().getContentLengthLong();
+
+            logger.debug("Received PUT request: partition={} fullKey={} requestId={}", partition, fullKey,
+                    requestId);
 
             if (requestId == null || requestId.isBlank()) {
                 ctx.status(400).result("Missing requestId parameter");
                 return;
             }
 
-            storageNode.store(partition, fullKey, requestId, Channels.newChannel(ctx.bodyInputStream()), length);
+            storageNode.store(partition, fullKey, requestId, Channels.newChannel(ctx.bodyInputStream()));
 
             ctx.status(200).result("OK");
             logger.debug("PUT (Uncommitted) partition={} fullKey={} requestId={}", partition, fullKey, requestId);

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeV2.java
@@ -125,13 +125,12 @@ protected void store(
             int partition,
             String key,
             String requestID,
-            ReadableByteChannel data,
-            long length) throws IOException {
+            ReadableByteChannel data) throws IOException {
 
         // 1. Perform the physical file write.
         Path path = getObjectPath(requestID);
         Files.createDirectories(path.getParent());
-        write(path, data, length);
+        write(path, data);
 
         // 2. Record the uncommitted write intent in the database
         try {
@@ -305,41 +304,41 @@ protected void store(
         return db.listItemsInBucket(bucketPrefix);
     }
 
-    private void write(Path path, ReadableByteChannel data, long length) throws IOException {
+   private void write(Path path, ReadableByteChannel data) throws IOException {
         try (FileChannel fc = FileChannel.open(path,
                 StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING,
                 StandardOpenOption.WRITE)) {
 
             long written = 0;
-            // Pre-allocate a 64KB direct buffer outside the loop for fallback reads
-            java.nio.ByteBuffer fallbackBuffer = java.nio.ByteBuffer.allocateDirect(64 * 1024);
+            // Define a chunk size (e.g., 8MB) to request in each transfer block
+            final long CHUNK_SIZE = 8 * 1024 * 1024; 
+            
+            // A tiny 1-byte buffer exclusively used to test for EOF
+            java.nio.ByteBuffer eofBuffer = java.nio.ByteBuffer.allocateDirect(1);
 
-            while (written < length) {
-                long n = fc.transferFrom(data, written, length - written);
-                if (n > 0) {
-                    written += n;
-                } else if (!data.isOpen()) {
-                    throw new IOException("Data channel closed before expected length was written");
+            while (true) {
+                long transferred = fc.transferFrom(data, written, CHUNK_SIZE);
+                
+                if (transferred > 0) {
+                    written += transferred;
                 } else {
-                    fallbackBuffer.clear();
-
-                    // Cap the buffer limit to avoid reading past the expected length
-                    int remaining = (int) Math.min((long) fallbackBuffer.capacity(), length - written);
-                    fallbackBuffer.limit(remaining);
-
-                    int readBytes = data.read(fallbackBuffer);
-
+                    // transferFrom returned 0. This means either:
+                    // 1. The stream is at EOF.
+                    // 2. The source channel has no bytes immediately available.
+                    
+                    // To definitively check for EOF without dropping data, attempt a 1-byte read.
+                    eofBuffer.clear();
+                    int readBytes = data.read(eofBuffer);
+                    
                     if (readBytes == -1) {
-                        throw new EOFException("Unexpected EOF. Expected " + length + " bytes, got " + written);
-                    }
-
-                    // Enforce the blocking mode assumption
-                    assert readBytes != 0 : "Blocking channel guarantee violated: read() returned 0 bytes";
-
-                    fallbackBuffer.flip();
-                    while (fallbackBuffer.hasRemaining()) {
-                        written += fc.write(fallbackBuffer, written);
+                        break; // EOF confirmed, exit the loop
+                    } else if (readBytes > 0) {
+                        // The stream wasn't at EOF, so write that 1 byte and continue
+                        eofBuffer.flip();
+                        while (eofBuffer.hasRemaining()) {
+                            written += fc.write(eofBuffer, written);
+                        }
                     }
                 }
             }

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeV2.java
@@ -114,14 +114,14 @@ public class StorageNodeV2 {
      * written to disk using a robust method that handles partial writes and ensures
      * data integrity. The file path is determined by the request ID, which allows
      * for sharding files into subdirectories based on their prefixes.
-     * 
-     * @param partition
-     * @param requestID
-     * @param data
-     * @param length
-     * @throws IOException
+     *
+     * @param partition the partition number for this store operation
+     * @param key the object key (bucket/object) identifying what is being stored
+     * @param requestID the unique request ID used to derive the file path
+     * @param data the data to write
+     * @throws IOException if the file cannot be written or the write intent cannot be recorded
      */
-protected void store(
+    protected void store(
             int partition,
             String key,
             String requestID,

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -55,8 +55,10 @@ class StorageNodeServerV2Test {
         db = new Database(new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString()));
         fetcher = new MemoryFetcher();
         metadataClient = new MetadataClient(fetcher);
+        metadataClient.start();
         pubSub = new MemoryPubSub();
         pubSubClient = new PubSubClient(pubSub);
+        pubSubClient.start();
         // Start the ACK blackhole server on a random port
         ackServer = Javalin.create(config -> {
             config.startup.showJavalinBanner = false;

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -43,8 +42,7 @@ class StorageNodeServerV2Test {
     private MemoryFetcher fetcher;
     private MemoryPubSub pubSub;
 
-    // A dummy server to absorb all the async ACKs and prevent connection errors in
-    // the logs
+    // A dummy server to absorb all the async ACKs and prevent connection errors in the logs
     private Javalin ackServer;
 
     @TempDir
@@ -55,14 +53,15 @@ class StorageNodeServerV2Test {
         db = new Database(new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString()));
         fetcher = new MemoryFetcher();
         metadataClient = new MetadataClient(fetcher);
-        metadataClient.start();
         pubSub = new MemoryPubSub();
         pubSubClient = new PubSubClient(pubSub);
+        metadataClient.start();
         pubSubClient.start();
-        // Start the ACK blackhole server on a random port
+        
+        // Start the ACK blackhole server on a random port (Updated to new path param spec)
         ackServer = Javalin.create(config -> {
             config.startup.showJavalinBanner = false;
-            config.routes.post("/ack", ctx -> ctx.status(200));
+            config.routes.post("/ack/{requestId}", ctx -> ctx.status(200));
         }).start(0);
 
         server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
@@ -85,30 +84,25 @@ class StorageNodeServerV2Test {
         ackServer.stop();
     }
 
-    private URI storeUri(int partition, String key) {
-        String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8);
-        return URI.create("http://localhost:" + port + "/store/" + partition + "/" + encodedKey);
+    private URI storeUri(int partition, String fullKey) {
+        return URI.create("http://localhost:" + port + "/store/" + partition + "/" + fullKey);
     }
 
-    private URI storeUriWithReq(int partition, String key, String reqId) {
-        String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8);
-        return URI
-                .create("http://localhost:" + port + "/store/" + partition + "/" + encodedKey + "?requestId=" + reqId);
+    private URI storeUriWithReq(int partition, String fullKey, String reqId) {
+        return URI.create("http://localhost:" + port + "/store/" + partition + "/" + fullKey + "?requestId=" + reqId);
     }
 
-    private URI storeUriWithVersion(int partition, String key, long version) {
-        String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8);
-        return URI
-                .create("http://localhost:" + port + "/store/" + partition + "/" + encodedKey + "?version=" + version);
+    private URI storeUriWithVersion(int partition, String fullKey, long version) {
+        return URI.create("http://localhost:" + port + "/store/" + partition + "/" + fullKey + "?version=" + version);
     }
 
     @Test
     void testPutMissingRequestId() throws Exception {
         int partition = 1;
-        String key = "missing-reqid";
+        String fullKey = "test-bucket/missing-reqid";
 
         HttpRequest putReq = HttpRequest.newBuilder()
-                .uri(storeUri(partition, key)) // Omitting ?requestId=
+                .uri(storeUri(partition, fullKey)) // Omitting ?requestId=
                 .PUT(HttpRequest.BodyPublishers.ofString("Data"))
                 .build();
 
@@ -120,10 +114,10 @@ class StorageNodeServerV2Test {
     @Test
     void testGetInvalidVersion() throws Exception {
         int partition = 1;
-        String key = "invalid-version-key";
+        String fullKey = "test-bucket/invalid-version-key";
 
         HttpRequest getReq = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:" + port + "/store/" + partition + "/" + key + "?version=abc"))
+                .uri(URI.create("http://localhost:" + port + "/store/" + partition + "/" + fullKey + "?version=abc"))
                 .GET()
                 .build();
 
@@ -135,11 +129,11 @@ class StorageNodeServerV2Test {
     @Test
     void testPutUncommittedAndGetNotFound() throws Exception {
         int partition = 1;
-        String key = "test-key";
+        String fullKey = "test-bucket/test-key";
         byte[] data = "Hello".getBytes(StandardCharsets.UTF_8);
 
         HttpRequest putReq = HttpRequest.newBuilder()
-                .uri(storeUriWithReq(partition, key, "req-1"))
+                .uri(storeUriWithReq(partition, fullKey, "req-1"))
                 .PUT(HttpRequest.BodyPublishers.ofByteArray(data))
                 .header("Content-Type", "application/octet-stream")
                 .build();
@@ -148,7 +142,7 @@ class StorageNodeServerV2Test {
         assertEquals(200, putResp.statusCode(), "PUT should succeed");
 
         HttpRequest getReq = HttpRequest.newBuilder()
-                .uri(storeUri(partition, key))
+                .uri(storeUri(partition, fullKey))
                 .GET()
                 .build();
 
@@ -190,24 +184,24 @@ class StorageNodeServerV2Test {
     @Test
     void testGetSpecificVersion() throws Exception {
         int partition = 3;
-        String key = "versioned-key";
+        String fullKey = "test-bucket/versioned-key";
 
         HttpRequest putReq1 = HttpRequest.newBuilder()
-                .uri(storeUriWithReq(partition, key, "req-v1"))
+                .uri(storeUriWithReq(partition, fullKey, "req-v1"))
                 .PUT(HttpRequest.BodyPublishers.ofString("Version 1"))
                 .build();
         http.send(putReq1, HttpResponse.BodyHandlers.ofString());
-        db.putItem(key, partition, 10L, "req-v1");
+        db.putItem(fullKey, partition, 10L, "req-v1");
 
         HttpRequest putReq2 = HttpRequest.newBuilder()
-                .uri(storeUriWithReq(partition, key, "req-v2"))
+                .uri(storeUriWithReq(partition, fullKey, "req-v2"))
                 .PUT(HttpRequest.BodyPublishers.ofString("Version 2"))
                 .build();
         http.send(putReq2, HttpResponse.BodyHandlers.ofString());
-        db.putItem(key, partition, 20L, "req-v2");
+        db.putItem(fullKey, partition, 20L, "req-v2");
 
         HttpRequest getV1 = HttpRequest.newBuilder()
-                .uri(storeUriWithVersion(partition, key, 10L))
+                .uri(storeUriWithVersion(partition, fullKey, 10L))
                 .GET()
                 .build();
         HttpResponse<String> respV1 = http.send(getV1, HttpResponse.BodyHandlers.ofString());
@@ -215,7 +209,7 @@ class StorageNodeServerV2Test {
         assertEquals("Version 1", respV1.body());
 
         HttpRequest getLatest = HttpRequest.newBuilder()
-                .uri(storeUri(partition, key))
+                .uri(storeUri(partition, fullKey))
                 .GET()
                 .build();
         HttpResponse<String> respLatest = http.send(getLatest, HttpResponse.BodyHandlers.ofString());
@@ -279,43 +273,43 @@ class StorageNodeServerV2Test {
         assertTrue(getResp.body().contains("chunk2"));
     }
 
-@Test
-void testProcessSequencerMessageSendsAck() throws Exception {
+    @Test
+    void testProcessSequencerMessageSendsAck() throws Exception {
         int partition = 1;
         String bucket = "ack-bucket";
         String reqId = "req-ack-123";
 
         CountDownLatch ackLatch = new CountDownLatch(1);
+        AtomicReference<String> receivedReqId = new AtomicReference<>();
 
-        // Start a dummy Javalin server on a random port to act as the sequencer
-        // callback endpoint
+        // Start a dummy Javalin server on a random port to act as the sequencer callback endpoint
         Javalin coordinator = Javalin.create(config -> {
-                config.concurrency.useVirtualThreads = true;
-                config.startup.showJavalinBanner = false;
-                config.http.maxRequestSize = 100_000_000L;
-                config.routes.post("/ack/{requestId}", ctx -> {
-                        ackLatch.countDown();
-                        ctx.status(200);
-                });
+            config.concurrency.useVirtualThreads = true;
+            config.startup.showJavalinBanner = false;
+            config.http.maxRequestSize = 100_000_000L;
+            config.routes.post("/ack/{requestId}", ctx -> {
+                receivedReqId.set(ctx.pathParam("requestId"));
+                ackLatch.countDown();
+                ctx.status(200);
+            });
         }).start(0);
 
         int callbackPort = coordinator.port();
         InetSocketAddress senderAddress = new InetSocketAddress("127.0.0.1", callbackPort);
 
-        // Create a simple message to trigger the sequencer processing and subsequent
-        // ACK
+        // Create a simple message to trigger the sequencer processing and subsequent ACK
         Message.CreateBucketMessage msg = new Message.CreateBucketMessage(bucket, reqId, senderAddress);
 
-        // Process the message (this handles the database operation and fires the async
-        // ACK)
+        // Process the message (this handles the database operation and fires the async ACK)
         server.processSequencerMessage(partition, msg, 1L);
 
         // Wait for the asynchronous HTTP client to send the request to the dummy server
         boolean received = ackLatch.await(5, TimeUnit.SECONDS);
 
         assertTrue(received, "ACK was not received by the callback server within the timeout limit");
-
-}
+        assertEquals(reqId, receivedReqId.get(), "ACK should use path parameter for requestId");
+        coordinator.stop();
+    }
 
     @Test
     void testGetCommittedButUnmaterializedRegularFile() throws Exception {
@@ -326,7 +320,6 @@ void testProcessSequencerMessageSendsAck() throws Exception {
         String reqId = "req-missing-123";
 
         // Commit the file metadata via sequencer message WITHOUT performing the HTTP PUT first.
-        // This simulates a scenario where the DB commit arrives but the file isn't on disk.
         server.processSequencerMessage(partition, 
             new Message.FileCommitMessage(bucket, key, reqId, getDummySender()), 300L);
 

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -277,26 +277,24 @@ class StorageNodeServerV2Test {
         assertTrue(getResp.body().contains("chunk2"));
     }
 
-    @Test
-    void testProcessSequencerMessageSendsAck() throws Exception {
+@Test
+void testProcessSequencerMessageSendsAck() throws Exception {
         int partition = 1;
         String bucket = "ack-bucket";
         String reqId = "req-ack-123";
 
         CountDownLatch ackLatch = new CountDownLatch(1);
-        AtomicReference<String> receivedBody = new AtomicReference<>();
 
         // Start a dummy Javalin server on a random port to act as the sequencer
         // callback endpoint
         Javalin coordinator = Javalin.create(config -> {
-            config.concurrency.useVirtualThreads = true;
-            config.startup.showJavalinBanner = false;
-            config.http.maxRequestSize = 100_000_000L;
-            config.routes.post("/ack", ctx -> {
-                receivedBody.set(ctx.body());
-                ackLatch.countDown();
-                ctx.status(200);
-            });
+                config.concurrency.useVirtualThreads = true;
+                config.startup.showJavalinBanner = false;
+                config.http.maxRequestSize = 100_000_000L;
+                config.routes.post("/ack/{requestId}", ctx -> {
+                        ackLatch.countDown();
+                        ctx.status(200);
+                });
         }).start(0);
 
         int callbackPort = coordinator.port();
@@ -314,10 +312,8 @@ class StorageNodeServerV2Test {
         boolean received = ackLatch.await(5, TimeUnit.SECONDS);
 
         assertTrue(received, "ACK was not received by the callback server within the timeout limit");
-        assertEquals("{\"requestId\":\"" + reqId + "\"}", receivedBody.get(),
-                "ACK payload should contain the correct JSON formatting");
 
-    }
+}
 
     @Test
     void testGetCommittedButUnmaterializedRegularFile() throws Exception {

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
@@ -54,8 +54,7 @@ public class StorageNodeV2Test {
         long seqNumber = 100L;
 
         // 1. Store data
-        storageNode.store(partition, key, requestID, Channels.newChannel(new ByteArrayInputStream(requestData)),
-                requestData.length);
+        storageNode.store(partition, key, requestID, Channels.newChannel(new ByteArrayInputStream(requestData)));
 
         // 2. Commit metadata
         storageNode.commit(partition, key, requestID, seqNumber);
@@ -101,7 +100,7 @@ public class StorageNodeV2Test {
         String requestID = "req-del";
 
         // Setup existing object
-        storageNode.store(1, key, requestID, Channels.newChannel(new ByteArrayInputStream("data".getBytes())), 4);
+        storageNode.store(1, key, requestID, Channels.newChannel(new ByteArrayInputStream("data".getBytes())));
         storageNode.commit(1, key, requestID, 10L);
 
         // Ensure it's there
@@ -125,14 +124,14 @@ public class StorageNodeV2Test {
         String requestID = "req-recreate";
 
         // Setup existing object
-        storageNode.store(1, key, requestID, Channels.newChannel(new ByteArrayInputStream("data".getBytes())), 4);
+        storageNode.store(1, key, requestID, Channels.newChannel(new ByteArrayInputStream("data".getBytes())));
         storageNode.commit(1, key, requestID, 10L);
 
         // Delete object
         storageNode.delete(1, key, 11L);
 
         // Recreate object
-        storageNode.store(1, key, requestID, Channels.newChannel(new ByteArrayInputStream("newdata".getBytes())), 7);
+        storageNode.store(1, key, requestID, Channels.newChannel(new ByteArrayInputStream("newdata".getBytes())));
         storageNode.commit(1, key, requestID, 12L);
 
         // Retrieve should get new data
@@ -193,13 +192,13 @@ public class StorageNodeV2Test {
     @Test
     public void testListItemsInBucket() throws Exception {
         String prefix = "test-bucket/";
-        storageNode.store(1,prefix+"file1", "req-1", Channels.newChannel(new ByteArrayInputStream("1".getBytes())), 1);
+        storageNode.store(1,prefix+"file1", "req-1", Channels.newChannel(new ByteArrayInputStream("1".getBytes())));
         storageNode.commit(1, prefix + "file1", "req-1", 100L);
 
-        storageNode.store(1, prefix+"file2","req-2", Channels.newChannel(new ByteArrayInputStream("2".getBytes())), 1);
+        storageNode.store(1, prefix+"file2","req-2", Channels.newChannel(new ByteArrayInputStream("2".getBytes())));
         storageNode.commit(1, prefix + "file2", "req-2", 101L);
 
-        storageNode.store(1,"other-bucket/file3", "req-3", Channels.newChannel(new ByteArrayInputStream("3".getBytes())), 1);
+        storageNode.store(1,"other-bucket/file3", "req-3", Channels.newChannel(new ByteArrayInputStream("3".getBytes())));
         storageNode.commit(1, "other-bucket/file3", "req-3", 102L);
 
         List<Metadata> items = storageNode.listItemsInBucket(prefix).toList();

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -18,6 +18,7 @@
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.2</junit.version>
+        <log4j.version>2.23.1</log4j.version>
     </properties>
 
     <dependencies>
@@ -32,6 +33,14 @@
             <artifactId>storage-node</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -41,14 +41,6 @@
             <scope>test</scope>
         </dependency>
 
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -209,6 +209,7 @@ public class RealStorageNodesIT {
     // -------------------------------------------------------
 
     @Test
+    @Disabled("Flaky in CI")
     void get_tolerates_three_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure tolerance test...");

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -209,7 +209,6 @@ public class RealStorageNodesIT {
     // -------------------------------------------------------
 
     @Test
-    @Disabled("Flaky in CI")
     void get_tolerates_three_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure tolerance test...");

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -174,7 +174,6 @@ public class RealStorageNodesIT {
     // MAIN ROUNDTRIP TEST
     // -------------------------------------------------------
     @Test
-    @Order(2)
     void put_get_roundTrip_realServers() throws Exception {
 
         log("Generating random test data...");
@@ -210,7 +209,6 @@ public class RealStorageNodesIT {
     // -------------------------------------------------------
 
     @Test
-    @Order(1)
     void get_tolerates_three_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure tolerance test...");
@@ -241,7 +239,6 @@ public class RealStorageNodesIT {
     }
 
     @Test
-    @Order(3)
     void get_fails_with_four_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure failure test...");

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -300,18 +300,6 @@ public class RealStorageNodesIT {
         }
     }
 
-    private static void waitForPort(InetSocketAddress addr, long timeoutMs) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline) {
-            try (Socket s = new Socket()) {
-                s.connect(addr, 50);
-                return; // success
-            } catch (IOException ignored) {}
-            Thread.sleep(50);
-        }
-        fail("Server port did not open: " + addr);
-    }
-
     private static void deleteRecursive(Path root) throws IOException {
         if (!Files.exists(root)) return;
 

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -1,15 +1,23 @@
 package koop;
 
+import com.github.koop.common.metadata.ErasureSetConfiguration;
+import com.github.koop.common.metadata.ErasureSetConfiguration.ErasureSet;
+import com.github.koop.common.metadata.ErasureSetConfiguration.Machine;
+import com.github.koop.common.metadata.MemoryFetcher;
+import com.github.koop.common.metadata.MetadataClient;
+import com.github.koop.common.metadata.PartitionSpreadConfiguration;
+import com.github.koop.common.metadata.PartitionSpreadConfiguration.PartitionSpread;
+import com.github.koop.common.pubsub.MemoryPubSub;
+import com.github.koop.common.pubsub.PubSubClient;
+import com.github.koop.queryprocessor.processor.CommitCoordinator;
 import com.github.koop.queryprocessor.processor.StorageWorker;
-import com.github.koop.storagenode.StorageNodeServer;
+import com.github.koop.storagenode.StorageNodeServerV2;
+import com.github.koop.storagenode.db.Database;
+import com.github.koop.storagenode.db.RocksDbStorageStrategy;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.Disabled;
 
 import java.io.*;
 import java.net.*;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.*;
 import java.security.SecureRandom;
 import java.time.LocalTime;
@@ -23,11 +31,17 @@ public class RealStorageNodesIT {
     private static final int TOTAL_NODES = 9;
     private static final int DATA_SIZE = 15 * 1024 * 1024; // 15MB
 
-    private final List<StorageNodeServer> servers = new ArrayList<>();
-    private final List<Thread> serverThreads = new ArrayList<>();
+    private final List<StorageNodeServerV2> servers = new ArrayList<>();
     private final List<Path> dataDirs = new ArrayList<>();
+    private final List<Database> databases = new ArrayList<>();
     private List<InetSocketAddress> addrs;
 
+    // Shared infrastructure for V2
+    private MemoryFetcher sharedFetcher;
+    private MemoryPubSub sharedPubSub;
+    private MetadataClient sharedMetadataClient;
+    private PubSubClient sharedPubSubClient;
+    private CommitCoordinator commitCoordinator;
     private StorageWorker worker;
 
     // -------------------------------------------------------
@@ -48,7 +62,21 @@ public class RealStorageNodesIT {
         log("=== STARTING STORAGE CLUSTER ===");
 
         addrs = new ArrayList<>();
+        sharedFetcher = new MemoryFetcher();
+        sharedPubSub = new MemoryPubSub();
 
+        // 1. Initialize shared control plane
+        sharedPubSubClient = new PubSubClient(sharedPubSub);
+        sharedPubSubClient.start();
+
+        sharedMetadataClient = new MetadataClient(sharedFetcher);
+        sharedMetadataClient.start();
+
+        // 2. Init QP Commit Coordinator and Storage Worker
+        commitCoordinator = new CommitCoordinator(sharedPubSubClient, 0, 10);
+        worker = new StorageWorker(sharedMetadataClient, commitCoordinator);
+
+        // 3. Start Storage Node Servers (V2)
         for (int i = 0; i < TOTAL_NODES; i++) {
 
             int port = freePort();
@@ -56,32 +84,61 @@ public class RealStorageNodesIT {
 
             log("Starting node " + i + " on port " + port);
 
-            StorageNodeServer server =
-                    new StorageNodeServer(port, dir);
+            // Each node gets its own Database instance but shares the memory-backed control planes
+            Database db = new Database(new RocksDbStorageStrategy(dir.resolve("db").toString()));
+            MetadataClient mc = new MetadataClient(sharedFetcher);
+            PubSubClient pc = new PubSubClient(sharedPubSub);
+
+            StorageNodeServerV2 server =
+                    new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"), mc, pc);
 
             servers.add(server);
             dataDirs.add(dir);
+            databases.add(db);
 
-            int nodeId = i;
+            log("[NODE " + i + "] server starting");
+            
+            // Start server directly (non-blocking in Javalin)
+            server.start();
 
-            Thread t = Thread.ofVirtual().start(() -> {
-                log("[NODE " + nodeId + "] accept loop starting");
-                server.start();
-            });
+            InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
+            
+            // Wait for port to open
+            waitForPort(addr, 5000);
 
-            serverThreads.add(t);
-
-            InetSocketAddress addr =
-                    new InetSocketAddress("127.0.0.1", port);
-
-            waitForHttpReady(addr, 5000);
-
-            log("[NODE " + nodeId + "] READY");
+            log("[NODE " + i + "] READY");
 
             addrs.add(addr);
         }
 
-        worker = new StorageWorker(addrs, addrs, addrs);
+        // 4. Populate cluster configuration so components can discover each other
+        ErasureSetConfiguration esConfig = new ErasureSetConfiguration();
+        ErasureSet es = new ErasureSet();
+        es.setNumber(1);
+        List<Machine> machines = new ArrayList<>();
+        for (InetSocketAddress addr : addrs) {
+            Machine m = new Machine();
+            m.setIp(addr.getHostString());
+            m.setPort(addr.getPort());
+            machines.add(m);
+        }
+        es.setMachines(machines);
+        esConfig.setErasureSets(List.of(es));
+
+        PartitionSpreadConfiguration psConfig = new PartitionSpreadConfiguration();
+        PartitionSpread ps = new PartitionSpread();
+        ps.setErasureSet(1);
+        List<Integer> parts = new ArrayList<>();
+        for(int i = 0; i < 99; i++) parts.add(i); // Assign all partitions to this set
+        ps.setPartitions(parts);
+        psConfig.setPartitionSpread(List.of(ps));
+
+        // Push updates to the shared MemoryFetcher
+        sharedFetcher.update(esConfig);
+        sharedFetcher.update(psConfig);
+
+        // Sleep briefly to let the pubsub/metadata configuration apply locally across the instances
+        Thread.sleep(1000);
 
         log("=== CLUSTER READY ===");
     }
@@ -94,19 +151,26 @@ public class RealStorageNodesIT {
 
         log("=== STOPPING CLUSTER ===");
 
+        if (worker != null) worker.shutdown();
+        if (sharedMetadataClient != null) sharedMetadataClient.close();
+        if (sharedPubSubClient != null) sharedPubSubClient.close();
+
         for (int i = 0; i < servers.size(); i++) {
             log("Stopping node " + i);
             servers.get(i).stop();
         }
 
-        for (Thread t : serverThreads)
-            t.join(1000);
+        for (Database db : databases) {
+            try { 
+                db.close(); 
+            } catch (Exception ignored) {}
+        }
 
         for (Path d : dataDirs)
             deleteRecursive(d);
 
         servers.clear();
-        serverThreads.clear();
+        databases.clear();
         dataDirs.clear();
 
         log("=== CLUSTER STOPPED ===");
@@ -115,9 +179,8 @@ public class RealStorageNodesIT {
     // -------------------------------------------------------
     // MAIN ROUNDTRIP TEST
     // -------------------------------------------------------
-    @Disabled("Storage node implementation not yet complete — re-enable when SN is ready")
     @Test
-    void put_get_delete_roundTrip_realServers() throws Exception {
+    void put_get_roundTrip_realServers() throws Exception {
 
         log("Generating random test data...");
         byte[] data = new byte[DATA_SIZE];
@@ -132,11 +195,10 @@ public class RealStorageNodesIT {
                         new ByteArrayInputStream(data));
 
         log("[WORKER] PUT result = " + putOk);
-        assertTrue(putOk);
+        assertTrue(putOk, "PUT should have successfully reached ACK quorum");
 
         log("[WORKER] GET starting...");
-        try (InputStream in =
-                     worker.get(UUID.randomUUID(), "b", "realA")) {
+        try (InputStream in = worker.get(UUID.randomUUID(), "b", "realA")) {
 
             byte[] got = in.readAllBytes();
 
@@ -145,13 +207,6 @@ public class RealStorageNodesIT {
             assertArrayEquals(data, got);
         }
 
-        log("[WORKER] DELETE starting...");
-        boolean delOk =
-                worker.delete(UUID.randomUUID(), "b", "realA");
-
-        log("[WORKER] DELETE result = " + delOk);
-        assertTrue(delOk);
-
         log("Round-trip test completed successfully.");
     }
 
@@ -159,10 +214,6 @@ public class RealStorageNodesIT {
     // ERASURE TESTS (real servers)
     // -------------------------------------------------------
 
-    /**
-     * M=3 parity shards, so losing any 3 shard servers should still reconstruct.
-     */
-    @Disabled("Storage node implementation not yet complete — re-enable when SN is ready")
     @Test
     void get_tolerates_three_node_failures_realServers() throws Exception {
 
@@ -193,12 +244,6 @@ public class RealStorageNodesIT {
         log("Erasure tolerance test (3 failures) completed successfully.");
     }
 
-    /**
-     * With K=6, M=3, losing 4 shards should be unrecoverable. Depending on the worker,
-     * this might throw during read, or might return a shorter/corrupt stream.
-     * We accept either behavior, but it must NOT return the full correct object.
-     */
-    @Disabled("Storage node implementation not yet complete — re-enable when SN is ready")
     @Test
     void get_fails_with_four_node_failures_realServers() throws Exception {
 
@@ -261,26 +306,16 @@ public class RealStorageNodesIT {
         }
     }
 
-    private static void waitForHttpReady(
-            InetSocketAddress addr,
-            long timeoutMs) throws InterruptedException {
-
+    private static void waitForPort(InetSocketAddress addr, long timeoutMs) throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;
-        HttpClient client = HttpClient.newHttpClient();
-        URI healthUri = URI.create("http://" + addr.getHostString() + ":" + addr.getPort() + "/health");
-
         while (System.currentTimeMillis() < deadline) {
-            try {
-                HttpRequest req = HttpRequest.newBuilder().uri(healthUri).GET().build();
-                HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
-                if (resp.statusCode() == 200) return;
-            } catch (IOException ignored) {
-                // server not ready yet
-            }
+            try (Socket s = new Socket()) {
+                s.connect(addr, 50);
+                return; // success
+            } catch (IOException ignored) {}
             Thread.sleep(50);
         }
-
-        fail("Server did not become ready: " + addr);
+        fail("Server port did not open: " + addr);
     }
 
     private static void deleteRecursive(Path root) throws IOException {

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class RealStorageNodesIT {
 
     private static final int TOTAL_NODES = 9;
-    private static final int DATA_SIZE = 15 * 1024 * 1024; // 15MB
+    private static final int DATA_SIZE = 5 * 1024 * 1024; // 15MB
 
     private final List<StorageNodeServerV2> servers = new ArrayList<>();
     private final List<Path> dataDirs = new ArrayList<>();
@@ -209,7 +209,6 @@ public class RealStorageNodesIT {
     // -------------------------------------------------------
 
     @Test
-    @Disabled("Flaky in CI")
     void get_tolerates_three_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure tolerance test...");

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -174,6 +174,7 @@ public class RealStorageNodesIT {
     // MAIN ROUNDTRIP TEST
     // -------------------------------------------------------
     @Test
+    @Order(2)
     void put_get_roundTrip_realServers() throws Exception {
 
         log("Generating random test data...");
@@ -209,6 +210,7 @@ public class RealStorageNodesIT {
     // -------------------------------------------------------
 
     @Test
+    @Order(1)
     void get_tolerates_three_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure tolerance test...");
@@ -239,6 +241,7 @@ public class RealStorageNodesIT {
     }
 
     @Test
+    @Order(3)
     void get_fails_with_four_node_failures_realServers() throws Exception {
 
         log("Generating random test data for erasure failure test...");

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -86,11 +86,8 @@ public class RealStorageNodesIT {
 
             // Each node gets its own Database instance but shares the memory-backed control planes
             Database db = new Database(new RocksDbStorageStrategy(dir.resolve("db").toString()));
-            MetadataClient mc = new MetadataClient(sharedFetcher);
-            PubSubClient pc = new PubSubClient(sharedPubSub);
-
             StorageNodeServerV2 server =
-                    new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"), mc, pc);
+                    new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"), sharedMetadataClient, sharedPubSubClient);
 
             servers.add(server);
             dataDirs.add(dir);
@@ -102,9 +99,6 @@ public class RealStorageNodesIT {
             server.start();
 
             InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
-            
-            // Wait for port to open
-            waitForPort(addr, 5000);
 
             log("[NODE " + i + "] READY");
 

--- a/system-tests/src/test/resources/log4j2-test.xml
+++ b/system-tests/src/test/resources/log4j2-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss} %-5level %logger - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+
+    <Root level="debug">
+      <AppenderRef ref="Console"/>
+    </Root>
+
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
## Human

Main goal with this PR was to get the basic integration tests in `RealStorageNodesIT` working with the new PUT protocol. Main issues addressed:

1. Inconsistency with ACK format in the StorageWorker listener and StorageNode send
2. Inconsistency with how bucket/key is formatted in the storage worker and expected in storage node --> standardized by listening on /bucket/key
3. starting the metadata client and closing it from within the storage node and storage worker --> start and close _outside_
4. all the storage node tests assumed a Content-Length header which wasn't necessary, and its not passed with the InputStream body, so I redid the `write` method to not use length and completely removed that

## AI Summary

This pull request introduces several improvements and refactorings to the metadata handling and storage logic, with a focus on simplifying configuration management, improving error handling, and standardizing storage key formatting. The most significant changes include centralizing configuration access in `StorageWorker`, updating the storage key format, enhancing the `MetadataClient` API, and updating test infrastructure to match the new conventions.

**Configuration and Metadata Management Improvements:**

* Refactored `StorageWorker` to retrieve `ErasureSetConfiguration` and `PartitionSpreadConfiguration` directly from the `MetadataClient` using a new `get()` method, eliminating the need for separate `AtomicReference` fields. Routing is now rebuilt automatically when both configurations are available, improving reliability and code clarity. [[1]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL355-R384) [[2]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL374-R403) [[3]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL134-R135) [[4]](diffhunk://#diff-5214008b582093d6611a82bdd12de9f83161c712f0db706a87a216344783437fR56-R78)
* Added `started` and `closed` state tracking to `MetadataClient`, along with corresponding checks and new methods (`isStarted()`, `isClosed()`). This prevents illegal state transitions and improves lifecycle management. [[1]](diffhunk://#diff-5214008b582093d6611a82bdd12de9f83161c712f0db706a87a216344783437fL17-R18) [[2]](diffhunk://#diff-5214008b582093d6611a82bdd12de9f83161c712f0db706a87a216344783437fR35-R40) [[3]](diffhunk://#diff-5214008b582093d6611a82bdd12de9f83161c712f0db706a87a216344783437fR56-R78)

**Storage Key Format Standardization:**

* Changed the storage key format from `bucket-key` to `bucket/key` in all relevant methods (`put`, `get`, `delete`) in `StorageWorker`, and updated the test server to use the new format for consistency. [[1]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL164-R177) [[2]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL249-R268) [[3]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL273-R307) Ffe6d21fL53R49, [[4]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfL31-R34)

**Error Handling and Logging Enhancements:**

* Improved error handling and logging in the reconstruction and upload phases, including better reporting for failed shard uploads and stream reconstruction errors. [[1]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dR240-R244) [[2]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL222-R230) [[3]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL420-R464) [[4]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL134-R135)

**Utility and Test Infrastructure Updates:**

* Updated `FakeStorageNodeServer` routes and handlers to match the new key format and improved code style for clarity. [[1]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfL31-R34) [[2]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfR52-R57)
* Improved test cleanup in `MetadataClientTest` to avoid double-closing the client.

These changes collectively make the codebase more robust, maintainable, and consistent.