### PR TITLE
Objectify settings

### DIFF
--- a/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
+++ b/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
@@ -29,9 +29,6 @@ import java.util.Arrays;
  */
 public final class ErasureCoder {
 
-    public static final int K = 6;
-    public static final int M = 3;
-    public static final int TOTAL = K + M;
     public static final int SHARD_SIZE = 1 << 20; // 1 MB per shard per stripe
 
     private ErasureCoder() {}
@@ -53,32 +50,30 @@ public final class ErasureCoder {
      * @param length number of bytes to read from {@code data}
      * @return array of {@value TOTAL} InputStreams, index 0..K-1 = data, K..TOTAL-1 = parity
      */
-    public static InputStream[] shard(InputStream data, long length) throws IOException {
+public static InputStream[] shard(InputStream data, long length, int k, int n) throws IOException {
         if (data == null) throw new IllegalArgumentException("data is null");
         if (length < 0) throw new IllegalArgumentException("length < 0");
 
-        long numStripes = (length + (long) K * SHARD_SIZE - 1) / ((long) K * SHARD_SIZE);
-        // Buffer enough for the whole file per shard so the encoder never blocks
-        // For large files this could be huge; cap at 8 stripes and rely on concurrent reads.
+        int m = n - k;
+        long numStripes = (length + (long) k * SHARD_SIZE - 1) / ((long) k * SHARD_SIZE);
         int pipeBuffer = (int) Math.min(8L * SHARD_SIZE, numStripes * SHARD_SIZE + 8);
 
-        PipedOutputStream[] pos = new PipedOutputStream[TOTAL];
-        PipedInputStream[] pis = new PipedInputStream[TOTAL];
-        for (int i = 0; i < TOTAL; i++) {
+        PipedOutputStream[] pos = new PipedOutputStream[n];
+        PipedInputStream[] pis = new PipedInputStream[n];
+        for (int i = 0; i < n; i++) {
             pos[i] = new PipedOutputStream();
             pis[i] = new PipedInputStream(pos[i], pipeBuffer);
         }
 
         Thread.startVirtualThread(() -> {
             try {
-                // 8-byte original-length prefix on every shard stream
                 byte[] lenBytes = new byte[8];
                 writeLong(lenBytes, length);
-                for (int i = 0; i < TOTAL; i++) pos[i].write(lenBytes);
+                for (int i = 0; i < n; i++) pos[i].write(lenBytes);
 
-                ReedSolomon rs = ReedSolomon.create(K, M);
-                byte[] stripeBuf = new byte[K * SHARD_SIZE];
-                byte[][] shards    = new byte[TOTAL][SHARD_SIZE];
+                ReedSolomon rs = ReedSolomon.create(k, m);
+                byte[] stripeBuf = new byte[k * SHARD_SIZE];
+                byte[][] shards    = new byte[n][SHARD_SIZE];
                 long remaining = length;
 
                 while (remaining > 0) {
@@ -90,31 +85,23 @@ public final class ErasureCoder {
                         Arrays.fill(stripeBuf, want, stripeBuf.length, (byte) 0);
                     }
 
-                    for (int i = 0; i < K; i++) {
+                    for (int i = 0; i < k; i++) {
                         System.arraycopy(stripeBuf, i * SHARD_SIZE, shards[i], 0, SHARD_SIZE);
                     }
-                    for (int i = K; i < TOTAL; i++) {
+                    for (int i = k; i < n; i++) {
                         Arrays.fill(shards[i], (byte) 0);
                     }
 
                     rs.encodeParity(shards, 0, SHARD_SIZE);
 
-                    for (int i = 0; i < TOTAL; i++) {
-                        pos[i].write(shards[i], 0, SHARD_SIZE);
-                    }
+                    for (int i = 0; i < n; i++) pos[i].write(shards[i], 0, SHARD_SIZE);
                 }
-
-                for (int i = 0; i < TOTAL; i++) pos[i].flush();
-
+                for (int i = 0; i < n; i++) pos[i].flush();
             } catch (IOException e) {
-                // Fall through to finally — closing pipes signals EOF to consumers
             } finally {
-                for (PipedOutputStream p : pos) {
-                    try { p.close(); } catch (IOException ignored) {}
-                }
+                for (PipedOutputStream p : pos) try { p.close(); } catch (IOException ignored) {}
             }
         });
-
         return pis;
     }
 
@@ -129,69 +116,64 @@ public final class ErasureCoder {
      * @param present boolean mask; {@code false} = shard unavailable
      * @return InputStream yielding exactly the original bytes
      */
-    public static InputStream reconstruct(InputStream[] shards, boolean[] present) throws IOException {
-        if (shards  == null || shards.length  != TOTAL) throw new IllegalArgumentException("shards must have length " + TOTAL);
-        if (present == null || present.length != TOTAL) throw new IllegalArgumentException("present must have length " + TOTAL);
+   public static InputStream reconstruct(InputStream[] shards, boolean[] present, int k, int n) throws IOException {
+        if (shards == null || shards.length != n) throw new IllegalArgumentException("shards must have length " + n);
+        if (present == null || present.length != n) throw new IllegalArgumentException("present must have length " + n);
 
         int count = 0;
         for (boolean b : present) if (b) count++;
-        if (count < K) throw new IllegalArgumentException("need at least " + K + " shards, got " + count);
+        if (count < k) throw new IllegalArgumentException("need at least " + k + " shards, got " + count);
 
-        DataInputStream[] dis = new DataInputStream[TOTAL];
-        for (int i = 0; i < TOTAL; i++) {
+        int m = n - k;
+        DataInputStream[] dis = new DataInputStream[n];
+        for (int i = 0; i < n; i++) {
             if (present[i]) dis[i] = new DataInputStream(new BufferedInputStream(shards[i]));
         }
 
         PipedOutputStream pos = new PipedOutputStream();
-        PipedInputStream pis = new PipedInputStream(pos, 4 * K * SHARD_SIZE);
-
-        final boolean[] pres = Arrays.copyOf(present, TOTAL);
+        PipedInputStream pis = new PipedInputStream(pos, 4 * k * SHARD_SIZE);
+        final boolean[] pres = Arrays.copyOf(present, n);
 
         Thread.startVirtualThread(() -> {
             try (pos) {
                 int first = -1;
-                for (int i = 0; i < TOTAL; i++) if (pres[i]) { first = i; break; }
+                for (int i = 0; i < n; i++) if (pres[i]) { first = i; break; }
 
                 long originalLength = dis[first].readLong();
-                for (int i = 0; i < TOTAL; i++) {
+                for (int i = 0; i < n; i++) {
                     if (pres[i] && i != first) dis[i].readLong();
                 }
 
-                ReedSolomon rs = ReedSolomon.create(K, M);
-                byte[][] stripe = new byte[TOTAL][SHARD_SIZE];
+                ReedSolomon rs = ReedSolomon.create(k, m);
+                byte[][] stripe = new byte[n][SHARD_SIZE];
                 long remaining = originalLength;
 
                 while (remaining > 0) {
-                    for (int i = 0; i < TOTAL; i++) {
+                    for (int i = 0; i < n; i++) {
                         if (pres[i]) readFully(dis[i], stripe[i], 0, SHARD_SIZE);
                     }
 
                     rs.decodeMissing(stripe, pres, 0, SHARD_SIZE);
 
-                    int toWrite = (int) Math.min((long) K * SHARD_SIZE, remaining);
+                    int toWrite = (int) Math.min((long) k * SHARD_SIZE, remaining);
                     int left = toWrite;
-                    for (int i = 0; i < K && left > 0; i++) {
-                        int n = Math.min(SHARD_SIZE, left);
-                        pos.write(stripe[i], 0, n);
-                        left -= n;
+                    for (int i = 0; i < k && left > 0; i++) {
+                        int nBytes = Math.min(SHARD_SIZE, left);
+                        pos.write(stripe[i], 0, nBytes);
+                        left -= nBytes;
                     }
                     remaining -= toWrite;
                 }
-
                 pos.flush();
-
             } catch (IOException e) {
-                // closing pos signals EOF to consumer
             } finally {
-                for (int i = 0; i < TOTAL; i++) {
+                for (int i = 0; i < n; i++) {
                     if (dis[i] != null) try { dis[i].close(); } catch (IOException ignored) {}
                 }
             }
         });
-
         return pis;
     }
-
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
+++ b/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
@@ -6,26 +6,26 @@ import java.io.*;
 import java.util.Arrays;
 
 /**
- * Stateless erasure coding utility using Reed-Solomon (6-of-9).
+ * Stateless erasure coding utility using Reed-Solomon with configurable {@code k}-of-{@code n}
+ * shard layouts.
  *
  * Sharding:
- *   {@link #shard(InputStream, long)} splits a data stream into K+M shard streams.
- *   The first K shards are data shards; the remaining M are parity shards.
- *   Each returned InputStream begins with an 8-byte original-length prefix so the
- *   receiver can trim padding on reconstruction.
+ * {@link #shard(InputStream, long, int, int)} splits a data stream into {@code n} shard streams.
+ * The first {@code k} shards are data shards; the remaining {@code n - k} shards are parity shards.
+ * Each returned {@link InputStream} begins with an 8-byte original-length prefix so the receiver
+ * can trim padding on reconstruction.
  *
  * Reconstruction:
- *   {@link #reconstruct(InputStream[], boolean[])} accepts up to K+M shard streams
- *   (false entries for missing shards) and returns the original data stream.
- *   At least K shards must be present.
+ * {@link #reconstruct(InputStream[], boolean[], int, int)} accepts up to {@code n} shard streams
+ * ({@code false} entries for missing shards) and returns the original data stream.
+ * At least {@code k} shards must be present.
  *
  * Concurrency note:
- *   The encoder runs in a single virtual thread and writes directly to each shard's
- *   PipedOutputStream. The pipe buffers are sized generously (4 * SHARD_SIZE each)
- *   so the encoder can run several stripes ahead of the consumers without blocking.
- *   The caller MUST drain all returned streams concurrently (e.g. one goroutine/thread
- *   per stream, or non-blocking I/O) — reading them sequentially will still deadlock
- *   once the pipe buffers fill up.
+ * The encoder runs in a single virtual thread and writes directly to each shard's
+ * {@link PipedOutputStream}. The pipe buffers are sized generously ({@code 4 * SHARD_SIZE} each)
+ * so the encoder can run several stripes ahead of the consumers without blocking.
+ * The caller MUST drain all returned streams concurrently (e.g. one thread per stream, or
+ * non-blocking I/O) — reading them sequentially will still deadlock once the pipe buffers fill up.
  */
 public final class ErasureCoder {
 
@@ -38,21 +38,27 @@ public final class ErasureCoder {
     // -------------------------------------------------------------------------
 
     /**
-     * Encodes {@code length} bytes from {@code data} into {@value TOTAL} shard streams.
+     * Encodes {@code length} bytes from {@code data} into {@code n} shard streams.
      *
      * <p>The returned streams MUST be consumed concurrently. The encoder runs in a
-     * background virtual thread; if the caller reads shard[0] to completion before
-     * touching shard[1], the encoder will block on a full shard[1] pipe — deadlock.
-     * In StorageWorker.put() the streams are forwarded to 9 independent socket writes
-     * which already run concurrently, so this is safe there.
+     * background virtual thread; if the caller reads {@code shard[0]} to completion before
+     * touching {@code shard[1]}, the encoder will block on a full pipe and deadlock.
+     * In {@code StorageWorker.put()} the streams are forwarded to {@code n} independent socket
+     * writes which already run concurrently, so this is safe there.
      *
-     * @param data   source data; must supply exactly {@code length} bytes
+     * @param data source data; must supply exactly {@code length} bytes
      * @param length number of bytes to read from {@code data}
-     * @return array of {@value TOTAL} InputStreams, index 0..K-1 = data, K..TOTAL-1 = parity
+     * @param k number of data shards to generate
+     * @param n total number of shards to generate, including parity shards
+     * @return array of {@code n} {@link InputStream}s, where indices {@code 0..k-1} are data
+     *         shards and {@code k..n-1} are parity shards
      */
-public static InputStream[] shard(InputStream data, long length, int k, int n) throws IOException {
+    public static InputStream[] shard(InputStream data, long length, int k, int n) throws IOException {
         if (data == null) throw new IllegalArgumentException("data is null");
         if (length < 0) throw new IllegalArgumentException("length < 0");
+        if(k==0) throw new IllegalArgumentException("k must be > 0");
+        if(n==0) throw new IllegalArgumentException("n must be > 0");
+        if(k>n) throw new IllegalArgumentException("k must be <= n");
 
         int m = n - k;
         long numStripes = (length + (long) k * SHARD_SIZE - 1) / ((long) k * SHARD_SIZE);
@@ -109,14 +115,16 @@ public static InputStream[] shard(InputStream data, long length, int k, int n) t
     // Reconstruction
     // -------------------------------------------------------------------------
 
-    /**
-     * Reconstructs the original data stream from at least {@value K} shard streams.
-     *
-     * @param shards  array of {@value TOTAL} shard InputStreams
-     * @param present boolean mask; {@code false} = shard unavailable
-     * @return InputStream yielding exactly the original bytes
-     */
-   public static InputStream reconstruct(InputStream[] shards, boolean[] present, int k, int n) throws IOException {
+        /**
+         * Reconstructs the original data stream from at least {@code k} shard streams.
+         *
+         * @param shards array of {@code n} shard {@link InputStream}s
+         * @param present boolean mask; {@code false} means the corresponding shard is unavailable
+         * @param k number of data shards required for reconstruction
+         * @param n total number of shards in the erasure set
+         * @return {@link InputStream} yielding exactly the original bytes
+         */
+        public static InputStream reconstruct(InputStream[] shards, boolean[] present, int k, int n) throws IOException {
         if (shards == null || shards.length != n) throw new IllegalArgumentException("shards must have length " + n);
         if (present == null || present.length != n) throw new IllegalArgumentException("present must have length " + n);
 

--- a/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
+++ b/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
@@ -17,6 +17,10 @@ public class ErasureSetConfiguration {
 
     public static class ErasureSet {
         private int number;
+        private int n;
+        private int k;
+        private int readQuorum;
+        private int writeQuorum;
         private List<Machine> machines;
 
         public int getNumber() {
@@ -25,6 +29,38 @@ public class ErasureSetConfiguration {
 
         public void setNumber(int number) {
             this.number = number;
+        }
+
+        public int getN() {
+            return n;
+        }
+
+        public void setN(int n) {
+            this.n = n;
+        }
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getReadQuorum() {
+            return readQuorum;
+        }
+
+        public void setReadQuorum(int readQuorum) {
+            this.readQuorum = readQuorum;
+        }
+
+        public int getWriteQuorum() {
+            return writeQuorum;
+        }
+
+        public void setWriteQuorum(int writeQuorum) {
+            this.writeQuorum = writeQuorum;
         }
 
         public List<Machine> getMachines() {

--- a/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
+++ b/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
@@ -19,7 +19,6 @@ public class ErasureSetConfiguration {
         private int number;
         private int n;
         private int k;
-        private int readQuorum;
         private int writeQuorum;
         private List<Machine> machines;
 
@@ -45,14 +44,6 @@ public class ErasureSetConfiguration {
 
         public void setK(int k) {
             this.k = k;
-        }
-
-        public int getReadQuorum() {
-            return readQuorum;
-        }
-
-        public void setReadQuorum(int readQuorum) {
-            this.readQuorum = readQuorum;
         }
 
         public int getWriteQuorum() {

--- a/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
+++ b/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
@@ -19,6 +19,7 @@ public class ErasureSetConfiguration {
         private int number;
         private int n;
         private int k;
+        @JsonProperty("write_quorum")
         private int writeQuorum;
         private List<Machine> machines;
 

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/CommitCoordinator.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/CommitCoordinator.java
@@ -128,16 +128,16 @@ public final class CommitCoordinator implements AutoCloseable {
     // -----------------------------------------------------------------------
 
     /**
-     * Publishes a single-part commit command and blocks until a quorum of Storage
-     * Nodes ACK the commit (or the timeout expires).
+     * Publishes a single-part commit command and blocks until the requested write quorum of
+     * Storage Nodes ACK the commit (or the timeout expires).
      *
      * @param requestId the UUID that was used for the preceding shard uploads.
      * @param partition the partition number — used as the Kafka topic via
      *                  {@link CommitTopics#forPartition}.
      * @param bucket    object bucket.
      * @param key       object key.
-     * @return {@code true} iff at least {@value #QUORUM} SNs ACKed within the
-     *         timeout.
+     * @param writeQuorum number of ACKs required before the commit is considered successful.
+     * @return {@code true} iff at least {@code writeQuorum} SNs ACKed within the timeout.
      */
     public boolean beginCommit(UUID requestId, int partition, String bucket, String key, int writeQuorum) {
         return runCommit(requestId, writeQuorum, () -> {
@@ -149,7 +149,7 @@ public final class CommitCoordinator implements AutoCloseable {
     }
 
     /**
-     * Publishes a multipart commit command and blocks until quorum.
+         * Publishes a multipart commit command and blocks until the requested write quorum is reached.
      *
      * @param requestId the UUID for the upload.
      * @param partition the partition number — used as the Kafka topic via
@@ -157,8 +157,8 @@ public final class CommitCoordinator implements AutoCloseable {
      * @param bucket    object bucket.
      * @param key       object key.
      * @param chunks    ordered list of part/chunk identifiers.
-     * @return {@code true} iff at least {@value #QUORUM} SNs ACKed within the
-     *         timeout.
+         * @param writeQuorum number of ACKs required before the commit is considered successful.
+         * @return {@code true} iff at least {@code writeQuorum} SNs ACKed within the timeout.
      */
     public boolean beginMultipartCommit(UUID requestId, int partition, String bucket, String key, List<String> chunks,
             int writeQuorum) {
@@ -208,12 +208,18 @@ public final class CommitCoordinator implements AutoCloseable {
      * {@link #beginMultipartCommit}.
      *
      * <ol>
-     * <li>Registers the pending commit <em>before</em> publishing, so no ACK can
-     * arrive before the entry exists in {@link #inFlight}.</li>
-     * <li>Runs {@code publishAction} to send the Kafka/pubsub message.</li>
-     * <li>Waits up to {@link #ackTimeoutSeconds}s for {@value #QUORUM} ACKs.</li>
+        * <li>Registers the pending commit <em>before</em> publishing, so no ACK can arrive before
+        * the entry exists in {@link #inFlight}.</li>
+        * <li>Runs {@code publishAction} to send the Kafka/pubsub message.</li>
+        * <li>Waits up to {@link #ackTimeoutSeconds}s for {@code writeQuorum} ACKs.</li>
      * <li>Cleans up the in-flight entry regardless of outcome.</li>
      * </ol>
+        *
+        * @param requestId unique identifier for the commit operation.
+        * @param writeQuorum number of ACKs required before the commit is considered successful.
+        * @param publishAction logic that publishes the commit message to pub/sub.
+        * @return {@code true} if the requested quorum is reached before the timeout, otherwise
+        *         {@code false}.
      */
     private boolean runCommit(UUID requestId, int writeQuorum, ThrowingRunnable publishAction) {
         String id = requestId.toString();

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/CommitCoordinator.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/CommitCoordinator.java
@@ -23,25 +23,28 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Coordinates the two-phase commit for PUT operations on the Query Processor side.
+ * Coordinates the two-phase commit for PUT operations on the Query Processor
+ * side.
  *
  * <h2>Protocol</h2>
  * <ol>
- *   <li>Caller invokes {@link #beginCommit} which:
- *       <ul>
- *         <li>Registers an in-flight {@link PendingCommit} keyed by {@code requestId}.</li>
- *         <li>Publishes a {@link FileCommitMessage} (or {@link MultipartCommitMessage})
- *             to the per-partition Kafka topic ({@code "partition-N"}) so every Storage
- *             Node for that partition receives the commit command.</li>
- *       </ul>
- *   </li>
- *   <li>Each SN that successfully commits POSTs to {@code /ack/{requestId}} on
- *       the Javalin HTTP server embedded in this coordinator.</li>
- *   <li>{@link #beginCommit} blocks until {@value #QUORUM} ACKs arrive or the
- *       timeout elapses, then returns {@code true}/{@code false}.</li>
+ * <li>Caller invokes {@link #beginCommit} which:
+ * <ul>
+ * <li>Registers an in-flight {@link PendingCommit} keyed by
+ * {@code requestId}.</li>
+ * <li>Publishes a {@link FileCommitMessage} (or {@link MultipartCommitMessage})
+ * to the per-partition Kafka topic ({@code "partition-N"}) so every Storage
+ * Node for that partition receives the commit command.</li>
+ * </ul>
+ * </li>
+ * <li>Each SN that successfully commits POSTs to {@code /ack/{requestId}} on
+ * the Javalin HTTP server embedded in this coordinator.</li>
+ * <li>{@link #beginCommit} blocks until {@value #QUORUM} ACKs arrive or the
+ * timeout elapses, then returns {@code true}/{@code false}.</li>
  * </ol>
  *
- * <p>The Javalin server is started once at construction time and shared across
+ * <p>
+ * The Javalin server is started once at construction time and shared across
  * all concurrent PUT operations — each pending commit is identified by its
  * {@code requestId} so concurrent operations do not interfere.
  */
@@ -69,7 +72,9 @@ public final class CommitCoordinator implements AutoCloseable {
     // State
     // -----------------------------------------------------------------------
 
-    /** Map from requestId to pending commit state. Thread-safe by ConcurrentHashMap. */
+    /**
+     * Map from requestId to pending commit state. Thread-safe by ConcurrentHashMap.
+     */
     private final ConcurrentHashMap<String, PendingCommit> inFlight = new ConcurrentHashMap<>();
 
     private final PubSubClient pubSubClient;
@@ -83,7 +88,8 @@ public final class CommitCoordinator implements AutoCloseable {
 
     /**
      * @param pubSubClient a started {@link PubSubClient} backed by Kafka (or
-     *                     {@link com.github.koop.common.pubsub.MemoryPubSub} in tests).
+     *                     {@link com.github.koop.common.pubsub.MemoryPubSub} in
+     *                     tests).
      * @param ackPort      the port this QP node should listen on for SN ACKs.
      *                     Pass {@code 0} to let the OS pick a free port.
      */
@@ -130,12 +136,12 @@ public final class CommitCoordinator implements AutoCloseable {
      *                  {@link CommitTopics#forPartition}.
      * @param bucket    object bucket.
      * @param key       object key.
-     * @return {@code true} iff at least {@value #QUORUM} SNs ACKed within the timeout.
+     * @return {@code true} iff at least {@value #QUORUM} SNs ACKed within the
+     *         timeout.
      */
-    public boolean beginCommit(UUID requestId, int partition, String bucket, String key) {
-        return runCommit(requestId, () -> {
-            FileCommitMessage msg = new FileCommitMessage(
-                    bucket, key, requestId.toString(), ackAddress);
+    public boolean beginCommit(UUID requestId, int partition, String bucket, String key, int writeQuorum) {
+        return runCommit(requestId, writeQuorum, () -> {
+            FileCommitMessage msg = new FileCommitMessage(bucket, key, requestId.toString(), ackAddress);
             String topic = CommitTopics.forPartition(partition);
             pubSubClient.pub(topic, Message.serializeMessage(msg));
             logger.debug("Published FileCommitMessage for requestId {} on topic {}", requestId, topic);
@@ -151,12 +157,14 @@ public final class CommitCoordinator implements AutoCloseable {
      * @param bucket    object bucket.
      * @param key       object key.
      * @param chunks    ordered list of part/chunk identifiers.
-     * @return {@code true} iff at least {@value #QUORUM} SNs ACKed within the timeout.
+     * @return {@code true} iff at least {@value #QUORUM} SNs ACKed within the
+     *         timeout.
      */
-    public boolean beginMultipartCommit(UUID requestId, int partition, String bucket, String key, List<String> chunks) {
-        return runCommit(requestId, () -> {
-            MultipartCommitMessage msg = new MultipartCommitMessage(
-                    bucket, key, requestId.toString(), ackAddress, chunks);
+    public boolean beginMultipartCommit(UUID requestId, int partition, String bucket, String key, List<String> chunks,
+            int writeQuorum) {
+        return runCommit(requestId, writeQuorum, () -> {
+            MultipartCommitMessage msg = new MultipartCommitMessage(bucket, key, requestId.toString(), ackAddress,
+                    chunks);
             String topic = CommitTopics.forPartition(partition);
             pubSubClient.pub(topic, Message.serializeMessage(msg));
             logger.debug("Published MultipartCommitMessage for requestId {} on topic {}", requestId, topic);
@@ -176,72 +184,60 @@ public final class CommitCoordinator implements AutoCloseable {
     /**
      * Javalin handler for {@code POST /ack/{requestId}}.
      *
-     * <p>Called by each Storage Node once it has committed the operation to its
+     * <p>
+     * Called by each Storage Node once it has committed the operation to its
      * op-log and metadata store. Decrements the {@link CountDownLatch} of the
      * matching in-flight commit, waking the blocked caller when quorum is reached.
      */
     private void handleAck(Context ctx) {
         String requestId = ctx.pathParam("requestId");
-
         PendingCommit commit = inFlight.get(requestId);
         if (commit == null) {
-            // Unknown or already-completed request — ignore gracefully.
             logger.warn("Received ACK for unknown requestId {}", requestId);
             ctx.status(404);
             return;
         }
-
         int acks = commit.ackCount.incrementAndGet();
-        logger.trace("ACK {}/{} received for requestId {}", acks, TOTAL_NODES, requestId);
-
-        // Release one permit on the latch; the committer thread wakes up as
-        // soon as QUORUM permits have been released. Extra ACKs (from nodes
-        // beyond QUORUM) call countDown() on an already-zero latch — safe no-op.
+        logger.trace("ACK {} received for requestId {}", acks, requestId);
         commit.latch.countDown();
-
         ctx.status(200);
     }
 
     /**
-     * Core template used by both {@link #beginCommit} and {@link #beginMultipartCommit}.
+     * Core template used by both {@link #beginCommit} and
+     * {@link #beginMultipartCommit}.
      *
      * <ol>
-     *   <li>Registers the pending commit <em>before</em> publishing, so no ACK can
-     *       arrive before the entry exists in {@link #inFlight}.</li>
-     *   <li>Runs {@code publishAction} to send the Kafka/pubsub message.</li>
-     *   <li>Waits up to {@link #ackTimeoutSeconds}s for {@value #QUORUM} ACKs.</li>
-     *   <li>Cleans up the in-flight entry regardless of outcome.</li>
+     * <li>Registers the pending commit <em>before</em> publishing, so no ACK can
+     * arrive before the entry exists in {@link #inFlight}.</li>
+     * <li>Runs {@code publishAction} to send the Kafka/pubsub message.</li>
+     * <li>Waits up to {@link #ackTimeoutSeconds}s for {@value #QUORUM} ACKs.</li>
+     * <li>Cleans up the in-flight entry regardless of outcome.</li>
      * </ol>
      */
-    private boolean runCommit(UUID requestId, ThrowingRunnable publishAction) {
+    private boolean runCommit(UUID requestId, int writeQuorum, ThrowingRunnable publishAction) {
         String id = requestId.toString();
-
-        PendingCommit commit = new PendingCommit(QUORUM);
+        PendingCommit commit = new PendingCommit(writeQuorum);
         inFlight.put(id, commit);
 
         try {
             publishAction.run();
-
             boolean quorumReached = commit.latch.await(ackTimeoutSeconds, TimeUnit.SECONDS);
 
             if (quorumReached) {
                 logger.info("Quorum reached for requestId {} ({} ACKs)", id, commit.ackCount.get());
             } else {
-                logger.warn("Timeout waiting for quorum on requestId {} (got {}/{})",
-                        id, commit.ackCount.get(), QUORUM);
+                logger.warn("Timeout waiting for quorum on requestId {} (got {}/{})", id, commit.ackCount.get(),
+                        writeQuorum);
             }
             return quorumReached;
-
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.warn("Interrupted waiting for ACKs on requestId {}", id);
             return false;
         } catch (Exception e) {
             logger.error("Error during commit for requestId {}: {}", id, e.getMessage(), e);
             return false;
         } finally {
-            // Always remove so late ACKs get 404 rather than matching a future
-            // request that happens to reuse the same UUID (defence-in-depth).
             inFlight.remove(id);
         }
     }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/ErasureRouting.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/ErasureRouting.java
@@ -18,18 +18,21 @@ import org.apache.logging.log4j.Logger;
  * node addresses responsible for that partition, driven entirely by live
  * metadata rather than hardcoded boundaries.
  *
- * <p>Partition assignment:
+ * <p>
+ * Partition assignment:
  * <ol>
- *   <li>Collect all partition numbers from all spread entries and sort them.</li>
- *   <li>Hash the key with CRC32 and mod by the total count to get an index.</li>
- *   <li>Look up the partition number at that index in the sorted list.</li>
+ * <li>Collect all partition numbers from all spread entries and sort them.</li>
+ * <li>Hash the key with CRC32 and mod by the total count to get an index.</li>
+ * <li>Look up the partition number at that index in the sorted list.</li>
  * </ol>
  *
- * <p>Sorting ensures that the same key always maps to the same partition number
+ * <p>
+ * Sorting ensures that the same key always maps to the same partition number
  * regardless of the order in which partitions appear in the config or how they
  * are redistributed across erasure sets.
  *
- * <p>Errors are logged and empty Optionals returned rather than throwing, so
+ * <p>
+ * Errors are logged and empty Optionals returned rather than throwing, so
  * that a bad config entry does not crash the query processor.
  */
 public final class ErasureRouting {
@@ -40,7 +43,7 @@ public final class ErasureRouting {
     private final ErasureSetConfiguration erasureSetConfig;
 
     public ErasureRouting(PartitionSpreadConfiguration partitionSpread,
-                          ErasureSetConfiguration erasureSetConfig) {
+            ErasureSetConfiguration erasureSetConfig) {
         if (partitionSpread == null)
             throw new IllegalArgumentException("partitionSpread is null");
         if (erasureSetConfig == null)
@@ -53,7 +56,8 @@ public final class ErasureRouting {
      * Returns the partition number that owns {@code key}, or an empty
      * {@link OptionalInt} if routing cannot be resolved.
      *
-     * <p>All partition numbers across all spread entries are collected and
+     * <p>
+     * All partition numbers across all spread entries are collected and
      * sorted so that the mapping is stable even if partition assignments are
      * redistributed between erasure sets.
      */
@@ -64,7 +68,8 @@ public final class ErasureRouting {
             return OptionalInt.empty();
         }
 
-        // Collect and sort all partition numbers for a stable, order-independent mapping
+        // Collect and sort all partition numbers for a stable, order-independent
+        // mapping
         List<Integer> allPartitions = spreads.stream()
                 .flatMap(s -> s.getPartitions().stream())
                 .sorted()
@@ -84,17 +89,13 @@ public final class ErasureRouting {
     }
 
     /**
-     * Returns the node addresses responsible for {@code partition}, or an empty
-     * {@link Optional} if nodes cannot be resolved.
-     *
-     * <p>Finds which spread entry owns the partition, reads its {@code erasure_set}
-     * number directly, looks up the matching {@link ErasureSetConfiguration.ErasureSet},
-     * and maps its machines to {@link InetSocketAddress} instances.
+     * Returns the ErasureSet responsible for {@code partition}, or an empty
+     * {@link Optional} if it cannot be resolved.
      */
-    public Optional<List<InetSocketAddress>> getNodes(int partition) {
+    public Optional<ErasureSetConfiguration.ErasureSet> getErasureSet(int partition) {
         var spreads = partitionSpread.getPartitionSpread();
         if (spreads == null || spreads.isEmpty()) {
-            logger.error("getNodes failed: PartitionSpreadConfiguration has no entries");
+            logger.error("getErasureSet failed: PartitionSpreadConfiguration has no entries");
             return Optional.empty();
         }
 
@@ -102,21 +103,18 @@ public final class ErasureRouting {
             if (spread.getPartitions().contains(partition)) {
                 int setNumber = spread.getErasureSet();
 
-                Optional<List<InetSocketAddress>> nodes = erasureSetConfig.getErasureSets().stream()
+                Optional<ErasureSetConfiguration.ErasureSet> erasureSet = erasureSetConfig.getErasureSets().stream()
                         .filter(es -> es.getNumber() == setNumber)
-                        .findFirst()
-                        .map(es -> es.getMachines().stream()
-                                .map(m -> new InetSocketAddress(m.getIp(), m.getPort()))
-                                .toList());
+                        .findFirst();
 
-                if (nodes.isEmpty()) {
-                    logger.error("getNodes failed: no erasure set found for set number {}", setNumber);
+                if (erasureSet.isEmpty()) {
+                    logger.error("getErasureSet failed: no erasure set found for set number {}", setNumber);
                 }
-                return nodes;
+                return erasureSet;
             }
         }
 
-        logger.error("getNodes failed: no spread entry found for partition {}", partition);
+        logger.error("getErasureSet failed: no spread entry found for partition {}", partition);
         return Optional.empty();
     }
 }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -206,7 +206,7 @@ public final class StorageWorker {
 
         executor.execute(() -> {
             try (pos) {
-                streamReconstruct(resolvedPartition, storageKey, resolvedNodes, es.getK(), es.getN(), es.getReadQuorum(), pos);
+                streamReconstruct(resolvedPartition, storageKey, resolvedNodes, es.getK(), es.getN(), pos);
             } catch (Exception e) {
                 logger.error("Failed to reconstruct stream for key {}", storageKey, e);
                 try {
@@ -369,7 +369,7 @@ public final class StorageWorker {
     }
 
     private void streamReconstruct(int partition, String storageKey,
-            List<InetSocketAddress> nodes, int k, int n, int readQuorum, OutputStream out) throws IOException {
+            List<InetSocketAddress> nodes, int k, int n, OutputStream out) throws IOException {
 
         InputStream[] ins = new InputStream[n];
         boolean[] present = new boolean[n];
@@ -398,8 +398,8 @@ public final class StorageWorker {
         for (boolean b : present)
             if (b)
                 count++;
-        if (count < readQuorum)
-            throw new IOException("lost too many shards; need " + readQuorum + ", got " + count);
+        if (count < k)
+            throw new IOException("lost too many shards; need " + k + ", got " + count);
 
         try (InputStream reconstructed = ErasureCoder.reconstruct(ins, present, k, n)) {
             byte[] buf = new byte[64 * 1024];

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -33,8 +33,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import static com.github.koop.common.erasure.ErasureCoder.TOTAL;
-
 /**
  * Distributes erasure-coded shards to storage nodes via HTTP.
  * Each storage node runs a Javalin server with endpoints:
@@ -84,19 +82,6 @@ public final class StorageWorker {
     // Public API
     // -------------------------------------------------------------------------
 
-    /**
-     * Executes a full PUT:
-     * <ol>
-     * <li>Erasure-code and stream shards to all
-     * {@value com.github.koop.common.erasure.ErasureCoder#TOTAL}
-     * storage nodes concurrently.</li>
-     * <li>Publish a commit message to the per-partition Kafka topic so every SN
-     * applies the operation to its op-log and metadata. SNs that missed the
-     * stream reconstruct their shard from peers before committing.</li>
-     * <li>Block until {@link CommitCoordinator#QUORUM} SN commit-ACKs are received,
-     * then return {@code true} to the caller.</li>
-     * </ol>
-     */
     public boolean put(UUID requestID, String bucket, String key, long length, InputStream data) throws IOException {
         if (requestID == null)
             throw new IllegalArgumentException("requestID is null");
@@ -112,25 +97,29 @@ public final class StorageWorker {
         String storageKey = bucket + "/" + key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
-        Optional<List<InetSocketAddress>> nodes = partition.isPresent()
-                ? r.getNodes(partition.getAsInt())
+        Optional<ErasureSetConfiguration.ErasureSet> erasureSetOpt = partition.isPresent()
+                ? r.getErasureSet(partition.getAsInt())
                 : Optional.empty();
-        if (partition.isEmpty() || nodes.isEmpty()) {
+
+        if (partition.isEmpty() || erasureSetOpt.isEmpty()) {
             logger.error("Routing failed for key {}, aborting put", storageKey);
             return false;
         }
+
         int resolvedPartition = partition.getAsInt();
-        List<InetSocketAddress> resolvedNodes = nodes.get();
+        ErasureSetConfiguration.ErasureSet es = erasureSetOpt.get();
+        List<InetSocketAddress> resolvedNodes = es.getMachines().stream()
+                .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
+
+        int n = es.getN();
+        int k = es.getK();
+        int writeQuorum = es.getWriteQuorum();
 
         // Phase 1 – stream erasure-coded shards to all storage nodes concurrently.
-        //
-        // All shard streams MUST be drained concurrently: ErasureCoder.shard()
-        // writes into 9 piped streams from a single encoder thread, so reading
-        // them sequentially would deadlock.
-        InputStream[] shardStreams = ErasureCoder.shard(data, length);
+        InputStream[] shardStreams = ErasureCoder.shard(data, length, k, n);
 
         List<Callable<Boolean>> tasks = new ArrayList<>();
-        for (int i = 0; i < TOTAL; i++) {
+        for (int i = 0; i < n; i++) {
             final int index = i;
             tasks.add(() -> {
                 InetSocketAddress node = resolvedNodes.get(index);
@@ -172,20 +161,15 @@ public final class StorageWorker {
             return false;
         }
 
-        if (uploaded < CommitCoordinator.QUORUM) {
-            logger.error("Phase 1 failed: only {}/{} shards uploaded. Aborting commit.", uploaded, TOTAL);
+        if (uploaded < writeQuorum) {
+            logger.error("Phase 1 failed: only {}/{} shards uploaded. Aborting commit.", uploaded, n);
             return false;
         }
 
-        logger.debug("Phase 1 complete: {}/{} shards uploaded for requestId {}", uploaded, TOTAL, requestID);
+        logger.debug("Phase 1 complete: {}/{} shards uploaded for requestId {}", uploaded, n, requestID);
 
         // Phase 2 – commit.
-        //
-        // Publish the commit message to the partition's Kafka topic. Every SN will:
-        // - add the op to its op-log + write metadata, if it received the shard; or
-        // - reconstruct the shard from peers and then commit, if it didn't.
-        // SNs POST an ACK back to this QP's server. We block until QUORUM ACKs arrive.
-        boolean committed = commitCoordinator.beginCommit(requestID, resolvedPartition, bucket, key);
+        boolean committed = commitCoordinator.beginCommit(requestID, resolvedPartition, bucket, key, writeQuorum);
         if (!committed) {
             logger.error("Commit phase failed for requestId {} (quorum ACKs not received)", requestID);
         }
@@ -203,22 +187,26 @@ public final class StorageWorker {
         String storageKey = bucket + "/" + key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
-        Optional<List<InetSocketAddress>> nodes = partition.isPresent()
-                ? r.getNodes(partition.getAsInt())
+        Optional<ErasureSetConfiguration.ErasureSet> erasureSetOpt = partition.isPresent()
+                ? r.getErasureSet(partition.getAsInt())
                 : Optional.empty();
-        if (partition.isEmpty() || nodes.isEmpty()) {
+
+        if (partition.isEmpty() || erasureSetOpt.isEmpty()) {
             logger.error("Routing failed for key {}, aborting get", storageKey);
             return InputStream.nullInputStream();
         }
+
         int resolvedPartition = partition.getAsInt();
-        List<InetSocketAddress> resolvedNodes = nodes.get();
+        ErasureSetConfiguration.ErasureSet es = erasureSetOpt.get();
+        List<InetSocketAddress> resolvedNodes = es.getMachines().stream()
+                .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
 
         PipedOutputStream pos = new PipedOutputStream();
         PipedInputStream pis = new PipedInputStream(pos, 256 * 1024);
 
         executor.execute(() -> {
             try (pos) {
-                streamReconstruct(resolvedPartition, storageKey, resolvedNodes, pos);
+                streamReconstruct(resolvedPartition, storageKey, resolvedNodes, es.getK(), es.getN(), es.getReadQuorum(), pos);
             } catch (Exception e) {
                 logger.error("Failed to reconstruct stream for key {}", storageKey, e);
                 try {
@@ -242,18 +230,22 @@ public final class StorageWorker {
         String storageKey = bucket + "/" + key;
         ErasureRouting r = getRouting();
         OptionalInt partition = r.getPartition(storageKey);
-        Optional<List<InetSocketAddress>> nodes = partition.isPresent()
-                ? r.getNodes(partition.getAsInt())
+        Optional<ErasureSetConfiguration.ErasureSet> erasureSetOpt = partition.isPresent()
+                ? r.getErasureSet(partition.getAsInt())
                 : Optional.empty();
-        if (partition.isEmpty() || nodes.isEmpty()) {
+
+        if (partition.isEmpty() || erasureSetOpt.isEmpty()) {
             logger.error("Routing failed for key {}, aborting delete", storageKey);
             return false;
         }
+
         int resolvedPartition = partition.getAsInt();
-        List<InetSocketAddress> resolvedNodes = nodes.get();
+        ErasureSetConfiguration.ErasureSet es = erasureSetOpt.get();
+        List<InetSocketAddress> resolvedNodes = es.getMachines().stream()
+                .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
 
         List<Callable<Boolean>> tasks = new LinkedList<>();
-        for (int i = 0; i < TOTAL; i++) {
+        for (int i = 0; i < es.getN(); i++) {
             final int index = i;
             tasks.add(() -> {
                 try {
@@ -298,10 +290,6 @@ public final class StorageWorker {
         return success;
     }
 
-    /**
-     * Starts multipart commit using the same partition routing and quorum-ACK
-     * flow as regular puts.
-     */
     public boolean beginMultipartCommit(String bucket, String key, String uploadId, List<String> chunks) {
         if (bucket == null)   throw new IllegalArgumentException("bucket is null");
         if (key == null)      throw new IllegalArgumentException("key is null");
@@ -324,9 +312,14 @@ public final class StorageWorker {
             return false;
         }
 
-        return commitCoordinator.beginMultipartCommit(requestId, partition.getAsInt(), bucket, key, chunks);
-    }
+        Optional<ErasureSetConfiguration.ErasureSet> erasureSetOpt = r.getErasureSet(partition.getAsInt());
+        if (erasureSetOpt.isEmpty()) {
+            logger.error("Routing failed for key {}, aborting multipart commit", storageKey);
+            return false;
+        }
 
+        return commitCoordinator.beginMultipartCommit(requestId, partition.getAsInt(), bucket, key, chunks, erasureSetOpt.get().getWriteQuorum());
+    }
 
     public void shutdown() {
         executor.shutdownNow();
@@ -350,12 +343,6 @@ public final class StorageWorker {
         });
     }
 
-    /**
-     * Rebuilds the shared {@link ErasureRouting} instance whenever either config
-     * is updated. Both configs must be present before routing can be constructed;
-     * if one hasn't arrived yet this is a no-op and the first update of the
-     * lagging config will trigger the rebuild instead.
-     */
     private void tryRebuildRouting() {
         PartitionSpreadConfiguration ps = metadataClient.get(PartitionSpreadConfiguration.class);
         ErasureSetConfiguration es = metadataClient.get(ErasureSetConfiguration.class);
@@ -369,10 +356,6 @@ public final class StorageWorker {
         }
     }
 
-    /**
-     * Returns the current {@link ErasureRouting}, which is rebuilt automatically
-     * whenever either config is updated via the metadata listener.
-     */
     private ErasureRouting getRouting() {
         ErasureRouting r = routing.get();
         if (r == null)
@@ -386,12 +369,12 @@ public final class StorageWorker {
     }
 
     private void streamReconstruct(int partition, String storageKey,
-            List<InetSocketAddress> nodes, OutputStream out) throws IOException {
+            List<InetSocketAddress> nodes, int k, int n, int readQuorum, OutputStream out) throws IOException {
 
-        InputStream[] ins = new InputStream[TOTAL];
-        boolean[] present = new boolean[TOTAL];
+        InputStream[] ins = new InputStream[n];
+        boolean[] present = new boolean[n];
 
-        for (int i = 0; i < TOTAL; i++) {
+        for (int i = 0; i < n; i++) {
             try {
                 InetSocketAddress node = nodes.get(i);
                 URI uri = URI.create(String.format("http://%s:%d/store/%d/%s",
@@ -415,23 +398,18 @@ public final class StorageWorker {
         for (boolean b : present)
             if (b)
                 count++;
-        if (count < ErasureCoder.K)
-            throw new IOException("lost too many shards; need " + ErasureCoder.K + ", got " + count);
+        if (count < readQuorum)
+            throw new IOException("lost too many shards; need " + readQuorum + ", got " + count);
 
-        try (InputStream reconstructed = ErasureCoder.reconstruct(ins, present)) {
+        try (InputStream reconstructed = ErasureCoder.reconstruct(ins, present, k, n)) {
             byte[] buf = new byte[64 * 1024];
-            int n;
-            while ((n = reconstructed.read(buf)) != -1)
-                out.write(buf, 0, n);
+            int bytesRead;
+            while ((bytesRead = reconstructed.read(buf)) != -1)
+                out.write(buf, 0, bytesRead);
         }
         out.flush();
     }
 
-    /**
-     * FOR TESTING ONLY - builds a PartitionSpreadConfiguration with 99 partitions
-     * spread evenly: partitions 0-32 → erasure set 1, 33-65 → erasure set 2, 66-98
-     * → erasure set 3.
-     */
     private static PartitionSpreadConfiguration buildTestPartitionSpread() {
         PartitionSpreadConfiguration ps = new PartitionSpreadConfiguration();
         List<PartitionSpread> spreads = new ArrayList<>();

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
@@ -453,7 +453,6 @@ public class StorageWorkerApiTest {
         es.setNumber(number);
         es.setN(9);
         es.setK(6);
-        es.setReadQuorum(6);
         es.setWriteQuorum(7);
         es.setMachines(addresses.stream().map(addr -> {
             Machine m = new Machine();

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
@@ -222,13 +222,6 @@ public class StorageWorkerApiTest {
     // New: commit-protocol tests
     // -------------------------------------------------------------------------
 
-    /**
-     * Verifies that the commit message is published to the partition-specific
-     * topic (e.g. "partition-5"), not a fixed topic like "storage-commits".
-     *
-     * We subscribe to the topic we expect, do a PUT, and assert we received
-     * a well-formed FileCommitMessage on exactly that topic.
-     */
     @Test
     void commitPublishedToPartitionTopic() throws Exception {
         PubSubClient spy = new PubSubClient(new MemoryPubSub());
@@ -240,11 +233,9 @@ public class StorageWorkerApiTest {
         List<InetSocketAddress> set = spyNodes.stream()
                 .map(AckingFakeStorageNodeServer::address).toList();
 
-        // Capture every message received on every partition topic.
         CopyOnWriteArrayList<String> receivedTopics = new CopyOnWriteArrayList<>();
         CopyOnWriteArrayList<Message> receivedMessages = new CopyOnWriteArrayList<>();
 
-        // Subscribe to all 99 partition topics.
         for (int p = 0; p < 99; p++) {
             String topic = CommitTopics.forPartition(p);
             spy.sub(topic, (t, offset, bytes) -> {
@@ -264,24 +255,19 @@ public class StorageWorkerApiTest {
                     data.length, new ByteArrayInputStream(data));
             assertTrue(ok, "put should succeed");
 
-            // Exactly one commit message must have been published.
             assertEquals(1, receivedMessages.size(),
                     "expected exactly one commit message");
 
-            // It must be a FileCommitMessage with matching fields.
             assertInstanceOf(FileCommitMessage.class, receivedMessages.get(0));
             FileCommitMessage msg = (FileCommitMessage) receivedMessages.get(0);
             assertEquals("bucket", msg.bucket());
             assertEquals("topicTest", msg.key());
             assertEquals(requestId.toString(), msg.requestID());
 
-            // The topic must be "partition-N" for the actual partition used.
             String publishedTopic = receivedTopics.get(0);
             assertTrue(publishedTopic.startsWith("partition-"),
                     "topic should be partition-based, got: " + publishedTopic);
 
-            // Cross-check: the topic the coordinator published on matches what
-            // topicFor() would produce for the resolved partition number.
             int partitionNum = Integer.parseInt(publishedTopic.substring("partition-".length()));
             assertEquals(CommitTopics.forPartition(partitionNum), publishedTopic);
         } finally {
@@ -290,14 +276,6 @@ public class StorageWorkerApiTest {
         }
     }
 
-    /**
-     * Verifies that put() returns false if fewer than QUORUM SNs ACK the commit
-     * (simulated by disabling 3 nodes so they never POST their ACKs, leaving
-     * only 6 ACKs — one below the quorum of 7).
-     *
-     * Because the real ACK timeout is long, we use a custom coordinator with a
-     * short timeout to keep the test fast.
-     */
     @Test
     void commitPhase_failsWhenBelowQuorum() throws Exception {
         PubSubClient bus = new PubSubClient(new MemoryPubSub());
@@ -309,14 +287,11 @@ public class StorageWorkerApiTest {
         List<InetSocketAddress> set = quorumNodes.stream()
                 .map(AckingFakeStorageNodeServer::address).toList();
 
-        // Disable 3 nodes — they receive the shard upload but will not ACK
-        // the commit (their ACK logic is also disabled).
         quorumNodes.get(0).setEnabled(false);
         quorumNodes.get(1).setEnabled(false);
         quorumNodes.get(2).setEnabled(false);
 
         MetadataClient client = createConfiguredClient(set);
-        // Use a short-timeout coordinator so the test doesn't wait 30 s.
         CommitCoordinator fastCoordinator = new CommitCoordinator(bus, 0, /*timeoutSeconds=*/ 3);
         StorageWorker quorumWorker = new StorageWorker(client, fastCoordinator);
 
@@ -332,11 +307,6 @@ public class StorageWorkerApiTest {
         }
     }
 
-    /**
-     * Verifies that put() succeeds even when 2 nodes are down during the upload
-     * phase (7 shards uploaded successfully, meeting QUORUM), and those 2 missing
-     * nodes still ACK via the commit path (simulating reconstruction from peers).
-     */
     @Test
     void commitPhase_succeedsWithTwoUploadFailuresThatLaterAck() throws Exception {
         PubSubClient bus = new PubSubClient(new MemoryPubSub());
@@ -348,8 +318,6 @@ public class StorageWorkerApiTest {
         List<InetSocketAddress> set = nodes2.stream()
                 .map(AckingFakeStorageNodeServer::address).toList();
 
-        // 2 nodes reject the shard upload but will still ACK the commit
-        // (they reconstruct from peers after seeing the Kafka message).
         nodes2.get(7).setUploadEnabled(false);
         nodes2.get(8).setUploadEnabled(false);
 
@@ -364,7 +332,6 @@ public class StorageWorkerApiTest {
             assertTrue(ok,
                     "put should succeed: 7 shards uploaded, all 9 nodes ACK after commit");
 
-            // Data must still be fully recoverable (7 shards is enough).
             try (InputStream in = w.get(UUID.randomUUID(), "b", "partialUpload")) {
                 assertArrayEquals(data, in.readAllBytes());
             }
@@ -374,10 +341,6 @@ public class StorageWorkerApiTest {
         }
     }
 
-    /**
-     * Verifies the ACK counter: after a successful put, every node that was
-     * enabled must have sent exactly one ACK back to the coordinator.
-     */
     @Test
     void commitPhase_eachEnabledNodeAcksExactlyOnce() throws Exception {
         PubSubClient bus = new PubSubClient(new MemoryPubSub());
@@ -408,11 +371,6 @@ public class StorageWorkerApiTest {
         }
     }
 
-    /**
-     * Verifies that multiple concurrent puts on different keys all complete
-     * successfully and their commit ACKs are correctly routed by requestId
-     * without cross-contamination.
-     */
     @Test
     void concurrentPuts_allSucceed() throws Exception {
         int concurrency = 5;
@@ -493,6 +451,10 @@ public class StorageWorkerApiTest {
     private static ErasureSet toErasureSet(int number, List<InetSocketAddress> addresses) {
         ErasureSet es = new ErasureSet();
         es.setNumber(number);
+        es.setN(9);
+        es.setK(6);
+        es.setReadQuorum(6);
+        es.setWriteQuorum(7);
         es.setMachines(addresses.stream().map(addr -> {
             Machine m = new Machine();
             m.setIp(addr.getHostString());

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -109,6 +109,11 @@ public class RealStorageNodesIT {
         ErasureSetConfiguration esConfig = new ErasureSetConfiguration();
         ErasureSet es = new ErasureSet();
         es.setNumber(1);
+        es.setN(9);
+        es.setK(6);
+        es.setReadQuorum(6);
+        es.setWriteQuorum(7);
+        
         List<Machine> machines = new ArrayList<>();
         for (InetSocketAddress addr : addrs) {
             Machine m = new Machine();

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -111,7 +111,6 @@ public class RealStorageNodesIT {
         es.setNumber(1);
         es.setN(9);
         es.setK(6);
-        es.setReadQuorum(6);
         es.setWriteQuorum(7);
         
         List<Machine> machines = new ArrayList<>();


### PR DESCRIPTION
This pull request introduces significant improvements to the erasure coding and commit coordination logic, making the system more flexible and configurable. The main changes include parameterizing erasure coding with dynamic `k` and `n` values, updating configuration classes to store these parameters, and modifying the commit coordinator to support per-operation write quorums. Additionally, there are several documentation and formatting improvements for clarity.

**Erasure Coding Flexibility:**

- The `ErasureCoder` class now accepts `k` (data shards) and `n` (total shards) as parameters instead of using fixed constants, allowing for configurable erasure coding schemes. This affects both the `shard` and `reconstruct` methods and their internal logic. [[1]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL32-L34) [[2]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL56-R76) [[3]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL93-L117) [[4]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL132-L194)

**Configuration Enhancements:**

- The `ErasureSet` inner class in `ErasureSetConfiguration` now includes fields for `n`, `k`, `readQuorum`, and `writeQuorum`, with corresponding getters and setters, enabling dynamic configuration of erasure coding and quorum requirements per set. [[1]](diffhunk://#diff-b169db2678793dbea838b444a844e66d51d1be351916f689b9b9a73ed01b1c8fR20-R23) [[2]](diffhunk://#diff-b169db2678793dbea838b444a844e66d51d1be351916f689b9b9a73ed01b1c8fR34-R65)

**Commit Coordination Improvements:**

- The `CommitCoordinator` now supports specifying the write quorum per commit operation, rather than relying on a fixed value. The `beginCommit`, `beginMultipartCommit`, and `runCommit` methods have been updated to accept a `writeQuorum` parameter, and related logging and state handling have been adjusted accordingly. [[1]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L133-R144) [[2]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L154-R167) [[3]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L216-L244)

**Documentation and Formatting:**

- Improved JavaDoc and code formatting in `CommitCoordinator` and `ErasureRouting` for better readability and clarity, including expanded comments and consistent paragraph formatting. [[1]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L26-R34) [[2]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L44-R47) [[3]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L72-R77) [[4]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L86-R92) [[5]](diffhunk://#diff-971d0125e5cedd6987833f250a599dd6e08a4196144afed4ec3c765782f56811L179-R208) [[6]](diffhunk://#diff-649b756b69ff94a2fd55d5807e4f68a658e778cd6320a9275ee89f7b94b20ca8L21-R35) [[7]](diffhunk://#diff-649b756b69ff94a2fd55d5807e4f68a658e778cd6320a9275ee89f7b94b20ca8L56-R60) [[8]](diffhunk://#diff-649b756b69ff94a2fd55d5807e4f68a658e778cd6320a9275ee89f7b94b20ca8L67-R72)

These changes collectively make the system more adaptable to different erasure coding strategies and operational requirements.