### PR TITLE
redis cache client and tests 

### DIFF
--- a/query-processor/pom.xml
+++ b/query-processor/pom.xml
@@ -98,6 +98,25 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.21.3</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClient.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClient.java
@@ -1,88 +1,276 @@
 package com.github.koop.queryprocessor.processor.cache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.params.SetParams;
+
+import java.net.URI;
 import java.util.Set;
 
 /**
- * Redis-backed CacheClient for production use.
- * Required for multi-QP deployments where different QP instances handle
- * different parts of the same multipart upload.
+ * Redis-backed {@link CacheClient} for production multi-QP deployments.
  *
- * Dependency (not yet added to pom.xml):
- *   io.lettuce:lettuce-core OR redis.clients:jedis
+ * <p>Backed by a {@link JedisPool} constructed from the {@code REDIS_URL}
+ * environment variable (e.g. {@code redis://redis-master:6379}). Falls back
+ * to {@code redis://localhost:6379} if the variable is not set.
  *
- * All methods throw UnsupportedOperationException until implemented.
+ * <p>Set semantics notes:
+ * <ul>
+ *   <li>{@link #setCreate} records set existence via a separate marker key
+ *       ({@code __set_exists__:{key}}) because Redis sets have no concept of
+ *       an empty set — they cease to exist when their last member is removed.
+ *       The marker is cleaned up by {@link #setDelete}.</li>
+ *   <li>{@link #setExists} checks the marker key, not the set itself.</li>
+ *   <li>{@link #setAddIfAbsent} requires the set to exist (marker present)
+ *       and adds the member only if it is not already in the set.</li>
+ *   <li>{@link #setAddIfPresent} requires the set to exist (marker present)
+ *       and adds the member unconditionally.</li>
+ * </ul>
+ *
+ * <p>All methods wrap Redis/IO errors in an unchecked
+ * {@link RuntimeException} so callers do not need to handle checked exceptions.
  */
 public class RedisCacheClient implements CacheClient {
 
-    // TODO: inject Redis client / connection pool.
+    private static final Logger logger = LogManager.getLogger(RedisCacheClient.class);
+
+    /** Prefix used to track whether a logical set has been created. */
+    private static final String SET_EXISTS_PREFIX = "__set_exists__:";
+
+    private final JedisPool pool;
+
+    // ─── Construction ─────────────────────────────────────────────────────────
+
+    /**
+     * Creates a client using the {@code REDIS_URL} environment variable.
+     * Falls back to {@code redis://localhost:6379} if not set.
+     */
+    public RedisCacheClient() {
+        this(System.getenv().getOrDefault("REDIS_URL", "redis://localhost:6379"));
+    }
+
+    /**
+     * Creates a client connecting to the given Redis URL.
+     *
+     * @param redisUrl e.g. {@code redis://redis-master:6379}
+     */
+    public RedisCacheClient(String redisUrl) {
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMaxTotal(32);
+        config.setMaxIdle(8);
+        config.setMinIdle(2);
+        config.setTestOnBorrow(true);
+        this.pool = new JedisPool(config, URI.create(redisUrl));
+        logger.info("RedisCacheClient connected to {}", redisUrl);
+    }
+
+    /** Package-private constructor for testing with a pre-built pool. */
+    RedisCacheClient(JedisPool pool) {
+        this.pool = pool;
+    }
+
+    // ─── Key-Value Operations ─────────────────────────────────────────────────
 
     @Override
     public void put(String key, String value) {
-        throw new UnsupportedOperationException("RedisCacheClient.put not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set(key, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis PUT failed for key: " + key, e);
+        }
     }
 
     @Override
     public void putWithTTL(String key, String value, long ttlSeconds) {
-        throw new UnsupportedOperationException("RedisCacheClient.putWithTTL not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            jedis.setex(key, ttlSeconds, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis SETEX failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Updates {@code key} only if it already exists (Redis {@code SET XX}).
+     *
+     * @return {@code true} if the key existed and was updated;
+     *         {@code false} if the key did not exist.
+     */
     @Override
     public boolean putIfPresent(String key, String value) {
-        throw new UnsupportedOperationException("RedisCacheClient.putIfPresent not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            // SET key value XX — only set if key already exists
+            String result = jedis.set(key, value, SetParams.setParams().xx());
+            return "OK".equals(result);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis SET XX failed for key: " + key, e);
+        }
     }
 
     @Override
     public String get(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.get not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            return jedis.get(key);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis GET failed for key: " + key, e);
+        }
     }
 
     @Override
     public void delete(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.delete not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            jedis.del(key);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis DEL failed for key: " + key, e);
+        }
     }
 
     @Override
     public boolean exists(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.exists not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            return jedis.exists(key);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis EXISTS failed for key: " + key, e);
+        }
     }
 
+    // ─── Set Operations ───────────────────────────────────────────────────────
+
+    /**
+     * Adds {@code member} to the set at {@code key}, creating it if absent.
+     * Does not require the set to have been created via {@link #setCreate}.
+     */
     @Override
     public void setAdd(String key, String member) {
-        throw new UnsupportedOperationException("RedisCacheClient.setAdd not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            jedis.sadd(key, member);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis SADD failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Adds {@code member} to the set at {@code key} only if the set exists
+     * (i.e. was previously created via {@link #setCreate}) and the member is
+     * not already present.
+     *
+     * @return {@code true} if the set existed and the member was newly added;
+     *         {@code false} if the set did not exist or the member was already present.
+     */
     @Override
     public boolean setAddIfAbsent(String key, String member) {
-        throw new UnsupportedOperationException("RedisCacheClient.setAddIfAbsent not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            if (!jedis.exists(setExistsKey(key))) {
+                return false;
+            }
+            // SADD returns 1 if member was added, 0 if already present
+            return jedis.sadd(key, member) == 1L;
+        } catch (Exception e) {
+            throw new RuntimeException("Redis setAddIfAbsent failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Adds {@code member} to the set at {@code key} only if the set exists
+     * (i.e. was previously created via {@link #setCreate}).
+     * The member is added unconditionally if the set exists.
+     *
+     * @return {@code true} if the set existed (member was added);
+     *         {@code false} if the set did not exist.
+     */
     @Override
     public boolean setAddIfPresent(String key, String member) {
-        throw new UnsupportedOperationException("RedisCacheClient.setAddIfPresent not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            if (!jedis.exists(setExistsKey(key))) {
+                return false;
+            }
+            jedis.sadd(key, member);
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Redis setAddIfPresent failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Removes {@code member} from the set at {@code key}.
+     *
+     * @return {@code true} if the member existed and was removed;
+     *         {@code false} if the set did not exist or the member was not present.
+     */
     @Override
     public boolean setRemove(String key, String member) {
-        throw new UnsupportedOperationException("RedisCacheClient.setRemove not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            // SREM returns the number of members removed
+            return jedis.srem(key, member) == 1L;
+        } catch (Exception e) {
+            throw new RuntimeException("Redis SREM failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Creates a logical empty set at {@code key} by writing a marker key.
+     * Subsequent calls to {@link #setExists}, {@link #setAddIfAbsent}, and
+     * {@link #setAddIfPresent} will treat this set as existing even while it
+     * has no members.
+     */
     @Override
     public void setCreate(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.setCreate not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            // SET NX so repeated calls are idempotent
+            jedis.set(setExistsKey(key), "1", SetParams.setParams().nx());
+        } catch (Exception e) {
+            throw new RuntimeException("Redis setCreate failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Returns {@code true} if the set was previously created via
+     * {@link #setCreate} and not yet deleted via {@link #setDelete}.
+     */
     @Override
     public boolean setExists(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.setExists not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            return jedis.exists(setExistsKey(key));
+        } catch (Exception e) {
+            throw new RuntimeException("Redis setExists failed for key: " + key, e);
+        }
     }
 
     @Override
     public Set<String> setMembers(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.setMembers not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            return jedis.smembers(key);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis SMEMBERS failed for key: " + key, e);
+        }
     }
 
+    /**
+     * Deletes the set and its existence marker.
+     */
     @Override
     public void setDelete(String key) {
-        throw new UnsupportedOperationException("RedisCacheClient.setDelete not implemented");
+        try (Jedis jedis = pool.getResource()) {
+            jedis.del(key, setExistsKey(key));
+        } catch (Exception e) {
+            throw new RuntimeException("Redis setDelete failed for key: " + key, e);
+        }
+    }
+
+    // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+    /**
+     * Closes the underlying connection pool. Call on application shutdown.
+     */
+    public void close() {
+        pool.close();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static String setExistsKey(String key) {
+        return SET_EXISTS_PREFIX + key;
     }
 }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClient.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClient.java
@@ -140,12 +140,17 @@ public class RedisCacheClient implements CacheClient {
 
     /**
      * Adds {@code member} to the set at {@code key}, creating it if absent.
-     * Does not require the set to have been created via {@link #setCreate}.
+     * Also writes the existence marker so that {@link #setExists} returns
+     * {@code true} after this call, consistent with the contract that
+     * {@code setAdd} creates the set if it does not yet exist.
      */
     @Override
     public void setAdd(String key, String member) {
         try (Jedis jedis = pool.getResource()) {
             jedis.sadd(key, member);
+            // Write marker NX so repeated setAdd calls don't overwrite a TTL
+            // that may have been set by an explicit setCreate call.
+            jedis.set(setExistsKey(key), "1", SetParams.setParams().nx());
         } catch (Exception e) {
             throw new RuntimeException("Redis SADD failed for key: " + key, e);
         }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClient.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClient.java
@@ -152,42 +152,57 @@ public class RedisCacheClient implements CacheClient {
     }
 
     /**
-     * Adds {@code member} to the set at {@code key} only if the set exists
-     * (i.e. was previously created via {@link #setCreate}) and the member is
-     * not already present.
+     * Atomically adds {@code member} to the set at {@code key} only if the set
+     * exists (marker present) and the member is not already in the set.
+     *
+     * <p>Implemented as a Lua script to guarantee atomicity — the marker check
+     * and SADD execute as a single Redis operation with no race window.
      *
      * @return {@code true} if the set existed and the member was newly added;
      *         {@code false} if the set did not exist or the member was already present.
      */
     @Override
     public boolean setAddIfAbsent(String key, String member) {
+        // KEYS[1] = marker key, KEYS[2] = set key, ARGV[1] = member
+        // Returns 1 if added, 0 if set doesn't exist or member already present
+        String script = """
+                if redis.call('EXISTS', KEYS[1]) == 0 then
+                    return 0
+                end
+                return redis.call('SADD', KEYS[2], ARGV[1])
+                """;
         try (Jedis jedis = pool.getResource()) {
-            if (!jedis.exists(setExistsKey(key))) {
-                return false;
-            }
-            // SADD returns 1 if member was added, 0 if already present
-            return jedis.sadd(key, member) == 1L;
+            Object result = jedis.eval(script, 2, setExistsKey(key), key, member);
+            return Long.valueOf(1L).equals(result);
         } catch (Exception e) {
             throw new RuntimeException("Redis setAddIfAbsent failed for key: " + key, e);
         }
     }
 
     /**
-     * Adds {@code member} to the set at {@code key} only if the set exists
-     * (i.e. was previously created via {@link #setCreate}).
-     * The member is added unconditionally if the set exists.
+     * Atomically adds {@code member} to the set at {@code key} only if the set
+     * exists (marker present). The member is added unconditionally if the set exists.
+     *
+     * <p>Implemented as a Lua script to guarantee atomicity — the marker check
+     * and SADD execute as a single Redis operation with no race window.
      *
      * @return {@code true} if the set existed (member was added);
      *         {@code false} if the set did not exist.
      */
     @Override
     public boolean setAddIfPresent(String key, String member) {
+        // KEYS[1] = marker key, KEYS[2] = set key, ARGV[1] = member
+        // Returns 1 if set existed (and member was added), 0 if set doesn't exist
+        String script = """
+                if redis.call('EXISTS', KEYS[1]) == 0 then
+                    return 0
+                end
+                redis.call('SADD', KEYS[2], ARGV[1])
+                return 1
+                """;
         try (Jedis jedis = pool.getResource()) {
-            if (!jedis.exists(setExistsKey(key))) {
-                return false;
-            }
-            jedis.sadd(key, member);
-            return true;
+            Object result = jedis.eval(script, 2, setExistsKey(key), key, member);
+            return Long.valueOf(1L).equals(result);
         } catch (Exception e) {
             throw new RuntimeException("Redis setAddIfPresent failed for key: " + key, e);
         }

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClientTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClientTest.java
@@ -220,4 +220,13 @@ class RedisCacheClientTest {
         assertTrue(client.setAddIfPresent("test:set:ifpresent", "a"));
         assertEquals(1, client.setMembers("test:set:ifpresent").size());
     }
+
+    @Test
+    @Order(22)
+    void setAdd_createsExistenceMarker() {
+        // setAdd should make setExists return true even without an explicit setCreate
+        assertFalse(client.setExists("test:set:basic"));
+        client.setAdd("test:set:basic", "a");
+        assertTrue(client.setExists("test:set:basic"));
+    }
 }

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClientTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/cache/RedisCacheClientTest.java
@@ -1,0 +1,223 @@
+package com.github.koop.queryprocessor.processor.cache;
+
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for {@link RedisCacheClient} using a Testcontainers-managed
+ * Redis instance. The container is started once for the entire test class and
+ * shared across all tests.
+ *
+ * Run with:
+ *   mvn test -pl query-processor -Dtest=RedisCacheClientTest
+ */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class RedisCacheClientTest {
+
+    @Container
+    static final GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    private RedisCacheClient client;
+
+    @BeforeAll
+    void setUp() {
+        String url = "redis://" + redis.getHost() + ":" + redis.getMappedPort(6379);
+        client = new RedisCacheClient(url);
+    }
+
+    @AfterAll
+    void tearDown() {
+        client.close();
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        client.delete("test:kv:key");
+        client.delete("test:kv:ttl");
+        client.delete("test:kv:ifpresent");
+        client.setDelete("test:set:basic");
+        client.setDelete("test:set:lifecycle");
+        client.setDelete("test:set:ifabsent");
+        client.setDelete("test:set:ifpresent");
+    }
+
+    // ─── Key-Value Tests ──────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void put_and_get_roundTrip() {
+        client.put("test:kv:key", "hello");
+        assertEquals("hello", client.get("test:kv:key"));
+    }
+
+    @Test
+    @Order(2)
+    void get_returnsNull_whenKeyAbsent() {
+        assertNull(client.get("test:kv:key"));
+    }
+
+    @Test
+    @Order(3)
+    void delete_removesKey() {
+        client.put("test:kv:key", "hello");
+        client.delete("test:kv:key");
+        assertNull(client.get("test:kv:key"));
+    }
+
+    @Test
+    @Order(4)
+    void exists_returnsTrue_whenKeyPresent() {
+        client.put("test:kv:key", "hello");
+        assertTrue(client.exists("test:kv:key"));
+    }
+
+    @Test
+    @Order(5)
+    void exists_returnsFalse_whenKeyAbsent() {
+        assertFalse(client.exists("test:kv:key"));
+    }
+
+    @Test
+    @Order(6)
+    void putWithTTL_keyExpiresAfterTTL() throws InterruptedException {
+        client.putWithTTL("test:kv:ttl", "expires", 1L);
+        assertEquals("expires", client.get("test:kv:ttl"));
+        Thread.sleep(2000);
+        assertNull(client.get("test:kv:ttl"));
+    }
+
+    @Test
+    @Order(7)
+    void putIfPresent_returnsFalse_whenKeyAbsent() {
+        assertFalse(client.putIfPresent("test:kv:ifpresent", "new-value"));
+        assertNull(client.get("test:kv:ifpresent"));
+    }
+
+    @Test
+    @Order(8)
+    void putIfPresent_returnsTrue_andUpdates_whenKeyPresent() {
+        client.put("test:kv:ifpresent", "original");
+        assertTrue(client.putIfPresent("test:kv:ifpresent", "updated"));
+        assertEquals("updated", client.get("test:kv:ifpresent"));
+    }
+
+    // ─── Set Tests ────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(9)
+    void setAdd_and_setMembers_roundTrip() {
+        client.setAdd("test:set:basic", "a");
+        client.setAdd("test:set:basic", "b");
+        client.setAdd("test:set:basic", "c");
+        assertEquals(Set.of("a", "b", "c"), client.setMembers("test:set:basic"));
+    }
+
+    @Test
+    @Order(10)
+    void setMembers_returnsEmptySet_whenKeyAbsent() {
+        assertTrue(client.setMembers("test:set:basic").isEmpty());
+    }
+
+    @Test
+    @Order(11)
+    void setRemove_returnsTrue_whenMemberRemoved() {
+        client.setAdd("test:set:basic", "a");
+        assertTrue(client.setRemove("test:set:basic", "a"));
+    }
+
+    @Test
+    @Order(12)
+    void setRemove_returnsFalse_whenMemberAbsent() {
+        assertFalse(client.setRemove("test:set:basic", "nonexistent"));
+    }
+
+    @Test
+    @Order(13)
+    void setCreate_setExists_setDelete_lifecycle() {
+        assertFalse(client.setExists("test:set:lifecycle"));
+
+        client.setCreate("test:set:lifecycle");
+        assertTrue(client.setExists("test:set:lifecycle"));
+
+        assertTrue(client.setMembers("test:set:lifecycle").isEmpty());
+
+        client.setDelete("test:set:lifecycle");
+        assertFalse(client.setExists("test:set:lifecycle"));
+    }
+
+    @Test
+    @Order(14)
+    void setCreate_isIdempotent() {
+        client.setCreate("test:set:lifecycle");
+        client.setCreate("test:set:lifecycle");
+        assertTrue(client.setExists("test:set:lifecycle"));
+    }
+
+    @Test
+    @Order(15)
+    void setDelete_removesMarkerAndMembers() {
+        client.setCreate("test:set:lifecycle");
+        client.setAdd("test:set:lifecycle", "member1");
+        client.setDelete("test:set:lifecycle");
+
+        assertFalse(client.setExists("test:set:lifecycle"));
+        assertTrue(client.setMembers("test:set:lifecycle").isEmpty());
+    }
+
+    @Test
+    @Order(16)
+    void setAddIfAbsent_returnsFalse_whenSetDoesNotExist() {
+        assertFalse(client.setAddIfAbsent("test:set:ifabsent", "a"));
+        assertTrue(client.setMembers("test:set:ifabsent").isEmpty());
+    }
+
+    @Test
+    @Order(17)
+    void setAddIfAbsent_returnsTrue_whenSetExistsAndMemberNew() {
+        client.setCreate("test:set:ifabsent");
+        assertTrue(client.setAddIfAbsent("test:set:ifabsent", "a"));
+        assertTrue(client.setMembers("test:set:ifabsent").contains("a"));
+    }
+
+    @Test
+    @Order(18)
+    void setAddIfAbsent_returnsFalse_whenMemberAlreadyPresent() {
+        client.setCreate("test:set:ifabsent");
+        client.setAdd("test:set:ifabsent", "a");
+        assertFalse(client.setAddIfAbsent("test:set:ifabsent", "a"));
+    }
+
+    @Test
+    @Order(19)
+    void setAddIfPresent_returnsFalse_whenSetDoesNotExist() {
+        assertFalse(client.setAddIfPresent("test:set:ifpresent", "a"));
+        assertTrue(client.setMembers("test:set:ifpresent").isEmpty());
+    }
+
+    @Test
+    @Order(20)
+    void setAddIfPresent_returnsTrue_andAddsMember_whenSetExists() {
+        client.setCreate("test:set:ifpresent");
+        assertTrue(client.setAddIfPresent("test:set:ifpresent", "a"));
+        assertTrue(client.setMembers("test:set:ifpresent").contains("a"));
+    }
+
+    @Test
+    @Order(21)
+    void setAddIfPresent_addsAgain_whenMemberAlreadyPresent() {
+        client.setCreate("test:set:ifpresent");
+        client.setAdd("test:set:ifpresent", "a");
+        assertTrue(client.setAddIfPresent("test:set:ifpresent", "a"));
+        assertEquals(1, client.setMembers("test:set:ifpresent").size());
+    }
+}


### PR DESCRIPTION
# Redis cache client implementation

## Summary

Implements `RedisCacheClient` — the production-ready replacement for `MemoryCacheClient` required for multi-QP deployments where different QP instances handle different parts of the same multipart upload. Also adds a Testcontainers-based integration test suite.

---

## Changes

### `RedisCacheClient`

Implements the full `CacheClient` interface backed by a Jedis connection pool. Reads connection config from the `REDIS_URL` environment variable (e.g. `redis://redis-master:6379` as defined in `docker-compose.yml`) with a fallback to `redis://localhost:6379`.

**Key-value operations** map directly to Redis primitives:
- `put` → `SET`
- `putWithTTL` → `SETEX`
- `putIfPresent` → `SET key value XX` — only writes if key already exists, matching `MemoryCacheClient`'s `computeIfPresent` semantics
- `get` → `GET`
- `delete` → `DEL`
- `exists` → `EXISTS`

**Set operations** use Redis sets (`SADD`, `SREM`, `SMEMBERS`) with one design consideration: Redis sets have no concept of an empty set — they cease to exist when their last member is removed. To support `setCreate` / `setExists` / `setDelete` semantics faithfully, a separate marker key (`__set_exists__:{key}`) tracks logical set existence. `setCreate` writes the marker with `SET NX` (idempotent), `setDelete` removes both the set and the marker atomically, and `setExists` checks the marker rather than the set itself.

`setAddIfAbsent` and `setAddIfPresent` both check the marker first — if the set was never created they return false without touching Redis. `setAddIfAbsent` then uses `SADD`'s return value (1 = newly added, 0 = already present) to determine whether the member was new.

All methods wrap Redis/IO errors in an unchecked `RuntimeException` consistent with the rest of the codebase. Connection pool is configured with 32 max connections and `testOnBorrow=true` to detect stale connections proactively.

### `RedisCacheClientTest`

Integration test suite covering all 21 behaviours using a Testcontainers-managed `redis:7-alpine` container. The container starts once for the class on a random port and is torn down after all tests complete — no manual Redis setup required.

Covers:
- `put` / `get` round-trip
- `get` returns null when key absent
- `delete` removes key
- `exists` true/false
- TTL expiry — puts with 1s TTL, sleeps 2s, asserts null
- `putIfPresent` returns false when key absent and does not create the key
- `putIfPresent` returns true and updates when key present
- `setAdd` / `setMembers` round-trip
- `setMembers` returns empty set when key absent
- `setRemove` true when member removed, false when absent
- `setCreate` / `setExists` / `setDelete` full lifecycle
- `setCreate` is idempotent
- `setDelete` removes both marker and members
- `setAddIfAbsent` false when set does not exist
- `setAddIfAbsent` true when set exists and member is new
- `setAddIfAbsent` false when member already present
- `setAddIfPresent` false when set does not exist
- `setAddIfPresent` true and adds member when set exists
- `setAddIfPresent` true and deduplicates when member already present

Run with:
```bash
mvn test -pl query-processor -Dtest=RedisCacheClientTest
```

### `query-processor/pom.xml`

Two new dependencies:

```xml
<dependency>
    <groupId>redis.clients</groupId>
    <artifactId>jedis</artifactId>
    <version>5.1.0</version>
</dependency>
<dependency>
      <groupId>org.testcontainers</groupId>
      <artifactId>testcontainers</artifactId>
      <scope>test</scope>
      <version>2.0.2</version>
</dependency>
<dependency>
      <groupId>org.testcontainers</groupId>
      <artifactId>junit-jupiter</artifactId>
      <version>1.21.3</version>
      <scope>test</scope>
</dependency>
```

---