### PR TITLE
Bucket

### DIFF
--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
@@ -448,10 +448,15 @@ public class Main {
         sb.append("  <MaxKeys>1000</MaxKeys>\n");
         sb.append("  <IsTruncated>false</IsTruncated>\n");
         for (ObjectSummary obj : objects) {
+            // S3 clients require LastModified to be a valid ISO-8601 timestamp;
+            // fall back to epoch when the storage layer doesn't supply one yet.
+            String lastModified = (obj.lastModified() == null || obj.lastModified().isEmpty())
+                    ? "1970-01-01T00:00:00.000Z"
+                    : obj.lastModified();
             sb.append("  <Contents>\n");
             sb.append("    <Key>").append(obj.key()).append("</Key>\n");
             sb.append("    <Size>").append(obj.size()).append("</Size>\n");
-            sb.append("    <LastModified>").append(obj.lastModified()).append("</LastModified>\n");
+            sb.append("    <LastModified>").append(lastModified).append("</LastModified>\n");
             //sb.append("    <ETag>\"").append(obj.etag()).append("\"</ETag>\n");
             sb.append("  </Contents>\n");
         }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
@@ -448,20 +448,14 @@ public class Main {
         sb.append("  <KeyCount>").append(objects.size()).append("</KeyCount>\n");
         sb.append("  <MaxKeys>").append(maxKeys).append("</MaxKeys>\n");
         sb.append("  <IsTruncated>false</IsTruncated>\n");
-        String bucketPrefix = bucket + "/";
         for (ObjectSummary obj : objects) {
             // S3 clients require LastModified to be a valid ISO-8601 timestamp;
             // fall back to epoch when the storage layer doesn't supply one yet.
             String lastModified = (obj.lastModified() == null || obj.lastModified().isEmpty())
                     ? "1970-01-01T00:00:00.000Z"
                     : obj.lastModified();
-            // Strip the internal "bucket/key" prefix so clients see just "key"
-            String key = obj.key();
-            if (key.startsWith(bucketPrefix)) {
-                key = key.substring(bucketPrefix.length());
-            }
             sb.append("  <Contents>\n");
-            sb.append("    <Key>").append(escapeXml(key)).append("</Key>\n");
+            sb.append("    <Key>").append(escapeXml(obj.key())).append("</Key>\n");
             sb.append("    <Size>").append(obj.size()).append("</Size>\n");
             sb.append("    <LastModified>").append(lastModified).append("</LastModified>\n");
             //sb.append("    <ETag>\"").append(obj.etag()).append("\"</ETag>\n");

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
@@ -44,14 +44,14 @@ public class Main {
      * │ GET     │ /{bucket}                    │ ListObjectsV2              │
      * │ HEAD    │ /{bucket}                    │ HeadBucket                 │
      * ├─────────┼──────────────────────────────┼────────────────────────────┤
-     * │ GET     │ /{bucket}/{key}              │ GetObject                  │
-     * │ DELETE  │ /{bucket}/{key}              │ DeleteObject               │
-     * │         │ /{bucket}/{key}?uploadId=X   │   └─ AbortMultipartUpload  │
-     * │ PUT     │ /{bucket}/{key}              │ PutObject                  │
-     * │         │ /{bucket}/{key}?partNumber=N │   └─ UploadPart            │
+     * │ GET     │ /{bucket}/<key>              │ GetObject                  │
+     * │ DELETE  │ /{bucket}/<key>              │ DeleteObject               │
+     * │         │ /{bucket}/<key>?uploadId=X   │   └─ AbortMultipartUpload  │
+     * │ PUT     │ /{bucket}/<key>              │ PutObject                  │
+     * │         │ /{bucket}/<key>?partNumber=N │   └─ UploadPart            │
      * │         │   &uploadId=X                │                            │
-     * │ POST    │ /{bucket}/{key}?uploads      │ CreateMultipartUpload      │
-     * │ POST    │ /{bucket}/{key}?uploadId=X   │ CompleteMultipartUpload    │
+     * │ POST    │ /{bucket}/<key>?uploads      │ CreateMultipartUpload      │
+     * │ POST    │ /{bucket}/<key>?uploadId=X   │ CompleteMultipartUpload    │
      * └─────────┴──────────────────────────────┴────────────────────────────┘
      */
     public static Javalin createApp(StorageService storage) {
@@ -68,17 +68,17 @@ public class Main {
             config.routes.head("/{bucket}",   ctx -> headBucketHandler(ctx, storage));
 
             // ── Object-level routes ─────────────────────────────────────────
-            // GET — plain object retrieval only (no multipart GET needed at gateway)
-            config.routes.get("/{bucket}/{key}", ctx -> getObjectHandler(ctx, storage));
+            // <key> is greedy so multi-segment S3 keys like "logs/jan.txt" match.
+            config.routes.get("/{bucket}/<key>", ctx -> getObjectHandler(ctx, storage));
 
             // DELETE — handles both DeleteObject and AbortMultipartUpload
-            config.routes.delete("/{bucket}/{key}", ctx -> deleteOrAbortHandler(ctx, storage));
+            config.routes.delete("/{bucket}/<key>", ctx -> deleteOrAbortHandler(ctx, storage));
 
             // PUT — handles both PutObject and UploadPart
-            config.routes.put("/{bucket}/{key}", ctx -> putOrUploadPartHandler(ctx, storage));
+            config.routes.put("/{bucket}/<key>", ctx -> putOrUploadPartHandler(ctx, storage));
 
             // POST — handles both CreateMultipartUpload (?uploads) and CompleteMultipartUpload (?uploadId=...)
-            config.routes.post("/{bucket}/{key}", ctx -> postObjectHandler(ctx, storage));
+            config.routes.post("/{bucket}/<key>", ctx -> postObjectHandler(ctx, storage));
         });
 
         return app;

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
@@ -159,7 +159,7 @@ public class Main {
             List<ObjectSummary> objects = storage.listObjects(bucket, prefix, maxKeys);
             ctx.status(200);
             ctx.header("Content-Type", "application/xml");
-            ctx.result(buildListObjectsXml(bucket, prefix, objects));
+            ctx.result(buildListObjectsXml(bucket, prefix, objects, maxKeys));
         } catch (UnsupportedOperationException e) {
             ctx.status(501);
             ctx.header("Content-Type", "application/xml");
@@ -431,30 +431,37 @@ public class Main {
     static String buildS3ErrorXml(String code, String message, String resource) {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                "<Error>\n" +
-               "  <Code>" + code + "</Code>\n" +
-               "  <Message>" + message + "</Message>\n" +
-               "  <Resource>" + resource + "</Resource>\n" +
+               "  <Code>" + escapeXml(code) + "</Code>\n" +
+               "  <Message>" + escapeXml(message) + "</Message>\n" +
+               "  <Resource>" + escapeXml(resource) + "</Resource>\n" +
                "  <RequestId>" + java.util.UUID.randomUUID() + "</RequestId>\n" +
                "</Error>";
     }
 
-    private static String buildListObjectsXml(String bucket, String prefix, List<ObjectSummary> objects) {
+    private static String buildListObjectsXml(String bucket, String prefix,
+                                               List<ObjectSummary> objects, int maxKeys) {
         StringBuilder sb = new StringBuilder();
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         sb.append("<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n");
-        sb.append("  <Name>").append(bucket).append("</Name>\n");
-        sb.append("  <Prefix>").append(prefix).append("</Prefix>\n");
+        sb.append("  <Name>").append(escapeXml(bucket)).append("</Name>\n");
+        sb.append("  <Prefix>").append(escapeXml(prefix)).append("</Prefix>\n");
         sb.append("  <KeyCount>").append(objects.size()).append("</KeyCount>\n");
-        sb.append("  <MaxKeys>1000</MaxKeys>\n");
+        sb.append("  <MaxKeys>").append(maxKeys).append("</MaxKeys>\n");
         sb.append("  <IsTruncated>false</IsTruncated>\n");
+        String bucketPrefix = bucket + "/";
         for (ObjectSummary obj : objects) {
             // S3 clients require LastModified to be a valid ISO-8601 timestamp;
             // fall back to epoch when the storage layer doesn't supply one yet.
             String lastModified = (obj.lastModified() == null || obj.lastModified().isEmpty())
                     ? "1970-01-01T00:00:00.000Z"
                     : obj.lastModified();
+            // Strip the internal "bucket/key" prefix so clients see just "key"
+            String key = obj.key();
+            if (key.startsWith(bucketPrefix)) {
+                key = key.substring(bucketPrefix.length());
+            }
             sb.append("  <Contents>\n");
-            sb.append("    <Key>").append(obj.key()).append("</Key>\n");
+            sb.append("    <Key>").append(escapeXml(key)).append("</Key>\n");
             sb.append("    <Size>").append(obj.size()).append("</Size>\n");
             sb.append("    <LastModified>").append(lastModified).append("</LastModified>\n");
             //sb.append("    <ETag>\"").append(obj.etag()).append("\"</ETag>\n");
@@ -467,20 +474,30 @@ public class Main {
     private static String buildInitiateMultipartUploadXml(String bucket, String key, String uploadId) {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                "<InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n" +
-               "  <Bucket>" + bucket + "</Bucket>\n" +
-               "  <Key>" + key + "</Key>\n" +
-               "  <UploadId>" + uploadId + "</UploadId>\n" +
+               "  <Bucket>" + escapeXml(bucket) + "</Bucket>\n" +
+               "  <Key>" + escapeXml(key) + "</Key>\n" +
+               "  <UploadId>" + escapeXml(uploadId) + "</UploadId>\n" +
                "</InitiateMultipartUploadResult>";
     }
 
     private static String buildCompleteMultipartUploadXml(String bucket, String key) {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                "<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n" +
-               "  <Location>http://localhost:8080/" + bucket + "/" + key + "</Location>\n" +
-               "  <Bucket>" + bucket + "</Bucket>\n" +
-               "  <Key>" + key + "</Key>\n" +
+               "  <Location>http://localhost:8080/" + escapeXml(bucket) + "/" + escapeXml(key) + "</Location>\n" +
+               "  <Bucket>" + escapeXml(bucket) + "</Bucket>\n" +
+               "  <Key>" + escapeXml(key) + "</Key>\n" +
                //"  <ETag>\"\"</ETag>\n" +
                "</CompleteMultipartUploadResult>";
+    }
+
+    /** Escapes XML special characters in text content. */
+    private static String escapeXml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
     /**

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/StorageServices/StorageWorkerService.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/StorageServices/StorageWorkerService.java
@@ -97,14 +97,14 @@ public class StorageWorkerService implements StorageService {
 
     @Override
     public List<ObjectSummary> listObjects(String bucket, String prefix, int maxKeys) throws Exception {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'listObjects'");
+        return storageWorker.listObjects(bucket, prefix, maxKeys).stream()
+                .map(o -> new ObjectSummary(o.key(), o.size(), o.lastModified()))
+                .toList();
     }
 
     @Override
     public boolean bucketExists(String bucket) throws Exception {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'bucketExists'");
+        return storageWorker.bucketExists(bucket);
     }
 
     @Override

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/StorageServices/StorageWorkerService.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/StorageServices/StorageWorkerService.java
@@ -97,8 +97,15 @@ public class StorageWorkerService implements StorageService {
 
     @Override
     public List<ObjectSummary> listObjects(String bucket, String prefix, int maxKeys) throws Exception {
+        String bucketPrefix = bucket + "/";
         return storageWorker.listObjects(bucket, prefix, maxKeys).stream()
-                .map(o -> new ObjectSummary(o.key(), o.size(), o.lastModified()))
+                .map(o -> {
+                    String key = o.key();
+                    if (key.startsWith(bucketPrefix)) {
+                        key = key.substring(bucketPrefix.length());
+                    }
+                    return new ObjectSummary(key, o.size(), o.lastModified());
+                })
                 .toList();
     }
 

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/StorageServices/StorageWorkerService.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/StorageServices/StorageWorkerService.java
@@ -79,14 +79,20 @@ public class StorageWorkerService implements StorageService {
 
     @Override
     public void createBucket(String bucket) throws Exception {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'createBucket'");
+        UUID requestId = UUID.randomUUID();
+        boolean success = storageWorker.createBucket(requestId, bucket);
+        if (!success) {
+            throw new RuntimeException("StorageWorker failed to create bucket");
+        }
     }
 
     @Override
     public void deleteBucket(String bucket) throws Exception {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'deleteBucket'");
+        UUID requestId = UUID.randomUUID();
+        boolean success = storageWorker.deleteBucket(requestId, bucket);
+        if (!success) {
+            throw new RuntimeException("StorageWorker failed to delete bucket");
+        }
     }
 
     @Override

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -526,9 +526,12 @@ public final class StorageWorker {
     }
 
     /**
-     * Checks whether a bucket exists by querying nodes in the partition's
-     * erasure set sequentially. Returns true on the first 200, false if all
-     * nodes either return 404 or fail.
+     * Checks whether a bucket exists by querying all nodes in the partition's
+     * erasure set concurrently. Returns {@code true} if any node returns 200
+     * (bucket exists), {@code false} only if every node returns 404 or fails.
+     *
+     * <p>This prevents false negatives when a node is stale or partitioned:
+     * even a single node reporting the bucket exists is sufficient.
      */
     public boolean bucketExists(String bucket) {
         if (bucket == null) throw new IllegalArgumentException("bucket is null");
@@ -542,24 +545,45 @@ public final class StorageWorker {
         List<InetSocketAddress> nodes = resolved.get().erasureSet().getMachines().stream()
                 .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
 
+        List<Callable<Boolean>> tasks = new ArrayList<>();
         for (InetSocketAddress node : nodes) {
-            URI uri = URI.create(String.format("http://%s:%d/bucket/%s",
-                    node.getHostString(), node.getPort(), bucket));
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(uri)
-                    .method("HEAD", HttpRequest.BodyPublishers.noBody())
-                    .build();
-            try {
-                HttpResponse<Void> resp = httpClient.send(req, HttpResponse.BodyHandlers.discarding());
-                int status = resp.statusCode();
-                if (status == 200) return true;
-                if (status == 404) return false;
-                logger.trace("HEAD bucket {} → node {} HTTP {}, trying next", bucket, node, status);
-            } catch (Exception e) {
-                logger.trace("HEAD bucket {} → node {} failed: {}", bucket, node, e.getMessage());
-            }
+            tasks.add(() -> {
+                URI uri = URI.create(String.format("http://%s:%d/bucket/%s",
+                        node.getHostString(), node.getPort(), bucket));
+                HttpRequest req = HttpRequest.newBuilder()
+                        .uri(uri)
+                        .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                        .build();
+                try {
+                    HttpResponse<Void> resp = httpClient.send(req, HttpResponse.BodyHandlers.discarding());
+                    int status = resp.statusCode();
+                    if (status == 200) return true;
+                    if (status == 404) {
+                        logger.trace("HEAD bucket {} → node {} HTTP 404, trying next", bucket, node);
+                        return false;
+                    }
+                    logger.trace("HEAD bucket {} → node {} HTTP {}, trying next", bucket, node, status);
+                } catch (Exception e) {
+                    logger.trace("HEAD bucket {} → node {} failed: {}", bucket, node, e.getMessage());
+                }
+                return false;
+            });
         }
-        return false;
+
+        try {
+            // Return true if ANY node reports the bucket exists
+            return executor.invokeAll(tasks).stream().anyMatch(f -> {
+                try {
+                    return f.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    logger.trace("bucketExists task error: {}", e.getMessage());
+                    return false;
+                }
+            });
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     /**

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -680,7 +680,7 @@ public final class StorageWorker {
             return result != null ? result : List.of();
         } catch (Exception e) {
             logger.warn("Failed to parse object list JSON (body length={}): {}",
-                        body.length(), e.getMessage());
+                        body != null ? body.length() : 0, e.getMessage());
             return List.of();
         }
     }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -525,6 +525,202 @@ public final class StorageWorker {
         return deleted;
     }
 
+    /**
+     * Checks whether a bucket exists by querying nodes in the partition's
+     * erasure set sequentially. Returns true on the first 200, false if all
+     * nodes either return 404 or fail.
+     */
+    public boolean bucketExists(String bucket) {
+        if (bucket == null) throw new IllegalArgumentException("bucket is null");
+
+        Optional<PartitionAndSet> resolved = resolveErasureSet(bucket);
+        if (resolved.isEmpty()) {
+            logger.error("Routing failed for bucket {}, aborting bucketExists", bucket);
+            return false;
+        }
+
+        List<InetSocketAddress> nodes = resolved.get().erasureSet().getMachines().stream()
+                .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
+
+        for (InetSocketAddress node : nodes) {
+            URI uri = URI.create(String.format("http://%s:%d/bucket/%s",
+                    node.getHostString(), node.getPort(), bucket));
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                    .build();
+            try {
+                HttpResponse<Void> resp = httpClient.send(req, HttpResponse.BodyHandlers.discarding());
+                int status = resp.statusCode();
+                if (status == 200) return true;
+                if (status == 404) return false;
+                logger.trace("HEAD bucket {} → node {} HTTP {}, trying next", bucket, node, status);
+            } catch (Exception e) {
+                logger.trace("HEAD bucket {} → node {} failed: {}", bucket, node, e.getMessage());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Lists objects in a bucket by fanning out a GET to one node per partition,
+     * merging results, deduping by key, sorting, and applying maxKeys.
+     */
+    public List<ObjectInfo> listObjects(String bucket, String prefix, int maxKeys) {
+        if (bucket == null) throw new IllegalArgumentException("bucket is null");
+        if (maxKeys < 0) throw new IllegalArgumentException("maxKeys < 0");
+
+        ErasureRouting r = getRouting();
+        var spreads = metadataClient.get(PartitionSpreadConfiguration.class).getPartitionSpread();
+        if (spreads == null || spreads.isEmpty()) {
+            logger.error("listObjects: no partition spread");
+            return List.of();
+        }
+
+        List<Integer> partitions = spreads.stream()
+                .flatMap(s -> s.getPartitions().stream())
+                .distinct()
+                .toList();
+
+        String safePrefix = prefix == null ? "" : prefix;
+        String query = "?maxKeys=" + maxKeys
+                + (safePrefix.isEmpty() ? "" : "&prefix=" + safePrefix);
+
+        List<Callable<List<ObjectInfo>>> tasks = new ArrayList<>();
+        for (int partition : partitions) {
+            Optional<ErasureSetConfiguration.ErasureSet> esOpt = r.getErasureSet(partition);
+            if (esOpt.isEmpty()) continue;
+            List<InetSocketAddress> nodes = esOpt.get().getMachines().stream()
+                    .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
+            if (nodes.isEmpty()) continue;
+            tasks.add(() -> fetchListFromAnyNode(bucket, query, nodes));
+        }
+
+        List<ObjectInfo> merged = new ArrayList<>();
+        try {
+            for (var future : executor.invokeAll(tasks)) {
+                try {
+                    merged.addAll(future.get());
+                } catch (ExecutionException e) {
+                    logger.warn("listObjects partition fetch failed: {}", e.getMessage());
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return List.of();
+        }
+
+        return merged.stream()
+                .collect(java.util.stream.Collectors.toMap(ObjectInfo::key, o -> o, (a, b) -> a))
+                .values().stream()
+                .sorted(Comparator.comparing(ObjectInfo::key))
+                .limit(maxKeys)
+                .toList();
+    }
+
+    private List<ObjectInfo> fetchListFromAnyNode(String bucket, String query, List<InetSocketAddress> nodes) {
+        for (InetSocketAddress node : nodes) {
+            URI uri = URI.create(String.format("http://%s:%d/bucket/%s%s",
+                    node.getHostString(), node.getPort(), bucket, query));
+            HttpRequest req = HttpRequest.newBuilder().uri(uri).GET().build();
+            try {
+                HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+                if (resp.statusCode() == 200) {
+                    return parseObjectListJson(resp.body());
+                }
+                logger.trace("GET list {} → node {} HTTP {}", bucket, node, resp.statusCode());
+            } catch (Exception e) {
+                logger.trace("GET list {} → node {} failed: {}", bucket, node, e.getMessage());
+            }
+        }
+        return List.of();
+    }
+
+    /** Parses the storage node's list response: [{"key":"..."},...]. */
+    private static List<ObjectInfo> parseObjectListJson(String body) {
+        if (body == null) return List.of();
+        String trimmed = body.trim();
+        if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return List.of();
+        String inner = trimmed.substring(1, trimmed.length() - 1).trim();
+        if (inner.isEmpty()) return List.of();
+
+        List<ObjectInfo> out = new ArrayList<>();
+        int depth = 0;
+        StringBuilder cur = new StringBuilder();
+        for (int i = 0; i < inner.length(); i++) {
+            char c = inner.charAt(i);
+            if (c == '{') depth++;
+            if (c == '}') depth--;
+            if (c == ',' && depth == 0) {
+                ObjectInfo oi = parseObjectEntry(cur.toString());
+                if (oi != null) out.add(oi);
+                cur.setLength(0);
+            } else {
+                cur.append(c);
+            }
+        }
+        if (cur.length() > 0) {
+            ObjectInfo oi = parseObjectEntry(cur.toString());
+            if (oi != null) out.add(oi);
+        }
+        return out;
+    }
+
+    private static ObjectInfo parseObjectEntry(String entry) {
+        int keyIdx = entry.indexOf("\"key\"");
+        if (keyIdx < 0) return null;
+        int firstQuote = entry.indexOf('"', entry.indexOf(':', keyIdx) + 1);
+        if (firstQuote < 0) return null;
+        StringBuilder key = new StringBuilder();
+        boolean escape = false;
+        int i = firstQuote + 1;
+        for (; i < entry.length(); i++) {
+            char c = entry.charAt(i);
+            if (escape) { key.append(c); escape = false; continue; }
+            if (c == '\\') { escape = true; continue; }
+            if (c == '"') break;
+            key.append(c);
+        }
+        long size = parseLongField(entry, "size");
+        String lastModified = parseStringField(entry, "lastModified");
+        return new ObjectInfo(key.toString(), size, lastModified);
+    }
+
+    private static long parseLongField(String entry, String field) {
+        int idx = entry.indexOf("\"" + field + "\"");
+        if (idx < 0) return 0L;
+        int colon = entry.indexOf(':', idx);
+        if (colon < 0) return 0L;
+        StringBuilder num = new StringBuilder();
+        for (int i = colon + 1; i < entry.length(); i++) {
+            char c = entry.charAt(i);
+            if (Character.isDigit(c) || c == '-') num.append(c);
+            else if (num.length() > 0) break;
+        }
+        try {
+            return num.length() == 0 ? 0L : Long.parseLong(num.toString());
+        } catch (NumberFormatException e) { return 0L; }
+    }
+
+    private static String parseStringField(String entry, String field) {
+        int idx = entry.indexOf("\"" + field + "\"");
+        if (idx < 0) return "";
+        int firstQuote = entry.indexOf('"', entry.indexOf(':', idx) + 1);
+        if (firstQuote < 0) return "";
+        StringBuilder val = new StringBuilder();
+        boolean escape = false;
+        for (int i = firstQuote + 1; i < entry.length(); i++) {
+            char c = entry.charAt(i);
+            if (escape) { val.append(c); escape = false; continue; }
+            if (c == '\\') { escape = true; continue; }
+            if (c == '"') break;
+            val.append(c);
+        }
+        return val.toString();
+    }
+
+    public record ObjectInfo(String key, long size, String lastModified) {}
+
     public boolean beginMultipartCommit(String bucket, String key, String uploadId, List<String> chunks) {
         if (bucket == null)
             throw new IllegalArgumentException("bucket is null");

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -10,6 +10,10 @@ import com.github.koop.common.pubsub.MemoryPubSub;
 import com.github.koop.common.pubsub.PubSubClient;
 import com.google.protobuf.ByteString.Output;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -661,87 +665,18 @@ public final class StorageWorker {
         return List.of();
     }
 
-    /** Parses the storage node's list response: [{"key":"..."},...]. */
+    /** Parses the storage node's list response: [{"key":"..."},...] using Jackson. */
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
     private static List<ObjectInfo> parseObjectListJson(String body) {
-        if (body == null) return List.of();
-        String trimmed = body.trim();
-        if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return List.of();
-        String inner = trimmed.substring(1, trimmed.length() - 1).trim();
-        if (inner.isEmpty()) return List.of();
-
-        List<ObjectInfo> out = new ArrayList<>();
-        int depth = 0;
-        StringBuilder cur = new StringBuilder();
-        for (int i = 0; i < inner.length(); i++) {
-            char c = inner.charAt(i);
-            if (c == '{') depth++;
-            if (c == '}') depth--;
-            if (c == ',' && depth == 0) {
-                ObjectInfo oi = parseObjectEntry(cur.toString());
-                if (oi != null) out.add(oi);
-                cur.setLength(0);
-            } else {
-                cur.append(c);
-            }
-        }
-        if (cur.length() > 0) {
-            ObjectInfo oi = parseObjectEntry(cur.toString());
-            if (oi != null) out.add(oi);
-        }
-        return out;
-    }
-
-    private static ObjectInfo parseObjectEntry(String entry) {
-        int keyIdx = entry.indexOf("\"key\"");
-        if (keyIdx < 0) return null;
-        int firstQuote = entry.indexOf('"', entry.indexOf(':', keyIdx) + 1);
-        if (firstQuote < 0) return null;
-        StringBuilder key = new StringBuilder();
-        boolean escape = false;
-        int i = firstQuote + 1;
-        for (; i < entry.length(); i++) {
-            char c = entry.charAt(i);
-            if (escape) { key.append(c); escape = false; continue; }
-            if (c == '\\') { escape = true; continue; }
-            if (c == '"') break;
-            key.append(c);
-        }
-        long size = parseLongField(entry, "size");
-        String lastModified = parseStringField(entry, "lastModified");
-        return new ObjectInfo(key.toString(), size, lastModified);
-    }
-
-    private static long parseLongField(String entry, String field) {
-        int idx = entry.indexOf("\"" + field + "\"");
-        if (idx < 0) return 0L;
-        int colon = entry.indexOf(':', idx);
-        if (colon < 0) return 0L;
-        StringBuilder num = new StringBuilder();
-        for (int i = colon + 1; i < entry.length(); i++) {
-            char c = entry.charAt(i);
-            if (Character.isDigit(c) || c == '-') num.append(c);
-            else if (num.length() > 0) break;
-        }
+        if (body == null || body.isBlank()) return List.of();
         try {
-            return num.length() == 0 ? 0L : Long.parseLong(num.toString());
-        } catch (NumberFormatException e) { return 0L; }
-    }
-
-    private static String parseStringField(String entry, String field) {
-        int idx = entry.indexOf("\"" + field + "\"");
-        if (idx < 0) return "";
-        int firstQuote = entry.indexOf('"', entry.indexOf(':', idx) + 1);
-        if (firstQuote < 0) return "";
-        StringBuilder val = new StringBuilder();
-        boolean escape = false;
-        for (int i = firstQuote + 1; i < entry.length(); i++) {
-            char c = entry.charAt(i);
-            if (escape) { val.append(c); escape = false; continue; }
-            if (c == '\\') { escape = true; continue; }
-            if (c == '"') break;
-            val.append(c);
+            List<ObjectInfo> result = OBJECT_MAPPER.readValue(body, new TypeReference<List<ObjectInfo>>() {});
+            return result != null ? result : List.of();
+        } catch (Exception e) {
+            return List.of();
         }
-        return val.toString();
     }
 
     public record ObjectInfo(String key, long size, String lastModified) {}

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -679,6 +679,8 @@ public final class StorageWorker {
             List<ObjectInfo> result = OBJECT_MAPPER.readValue(body, new TypeReference<List<ObjectInfo>>() {});
             return result != null ? result : List.of();
         } catch (Exception e) {
+            logger.warn("Failed to parse object list JSON (body length={}): {}",
+                        body.length(), e.getMessage());
             return List.of();
         }
     }

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -554,7 +555,8 @@ public final class StorageWorker {
         for (InetSocketAddress node : nodes) {
             tasks.add(() -> {
                 URI uri = URI.create(String.format("http://%s:%d/bucket/%s",
-                        node.getHostString(), node.getPort(), bucket));
+                        node.getHostString(), node.getPort(),
+                        URLEncoder.encode(bucket, java.nio.charset.StandardCharsets.UTF_8)));
                 HttpRequest req = HttpRequest.newBuilder()
                         .uri(uri)
                         .method("HEAD", HttpRequest.BodyPublishers.noBody())
@@ -612,8 +614,9 @@ public final class StorageWorker {
                 .toList();
 
         String safePrefix = prefix == null ? "" : prefix;
+        String encodedPrefix = URLEncoder.encode(safePrefix, java.nio.charset.StandardCharsets.UTF_8);
         String query = "?maxKeys=" + maxKeys
-                + (safePrefix.isEmpty() ? "" : "&prefix=" + safePrefix);
+                + (safePrefix.isEmpty() ? "" : "&prefix=" + encodedPrefix);
 
         List<Callable<List<ObjectInfo>>> tasks = new ArrayList<>();
         for (int partition : partitions) {
@@ -650,7 +653,8 @@ public final class StorageWorker {
     private List<ObjectInfo> fetchListFromAnyNode(String bucket, String query, List<InetSocketAddress> nodes) {
         for (InetSocketAddress node : nodes) {
             URI uri = URI.create(String.format("http://%s:%d/bucket/%s%s",
-                    node.getHostString(), node.getPort(), bucket, query));
+                    node.getHostString(), node.getPort(),
+                    URLEncoder.encode(bucket, java.nio.charset.StandardCharsets.UTF_8), query));
             HttpRequest req = HttpRequest.newBuilder().uri(uri).GET().build();
             try {
                 HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/gateway/S3Test.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/gateway/S3Test.java
@@ -562,10 +562,72 @@ class S3Test {
         verify(mockStorage).listObjects(eq(BUCKET), eq("logs/"), anyInt());
     }
 
+    @Test
+    @Order(26)
+    void sdkListObjects_keysDoNotIncludeBucketPrefix() throws Exception {
+        // StorageWorkerService returns keys as "bucket/key" from the storage layer.
+        // The XML builder should strip the bucket prefix so clients see just "key".
+        List<ObjectSummary> summaries = List.of(
+                new ObjectSummary(BUCKET + "/photo.jpg", 100L, "2025-01-01T00:00:00Z")
+        );
+        when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
+                .thenReturn(summaries);
+
+        ListObjectsV2Response response = s3.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(BUCKET).build()
+        );
+
+        assertEquals(1, response.keyCount());
+        assertEquals("photo.jpg", response.contents().get(0).key(),
+                "Key should not include the bucket prefix, but got: "
+                        + response.contents().get(0).key());
+    }
+
+    @Test
+    @Order(27)
+    void sdkListObjects_keysWithSpecialCharsProduceValidXml() throws Exception {
+        // Keys containing XML special characters (&, <, >) must be escaped in the
+        // XML response. If not escaped, the AWS SDK's XML parser will fail.
+        List<ObjectSummary> summaries = List.of(
+                new ObjectSummary("a&b<c.txt", 50L, "2025-01-01T00:00:00Z")
+        );
+        when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
+                .thenReturn(summaries);
+
+        // This should NOT throw — if XML is invalid the SDK will throw S3Exception
+        ListObjectsV2Response response = assertDoesNotThrow(() ->
+                s3.listObjectsV2(ListObjectsV2Request.builder().bucket(BUCKET).build()),
+                "Keys with XML special characters should not break the XML response"
+        );
+
+        assertEquals(1, response.keyCount());
+        assertEquals("a&b<c.txt", response.contents().get(0).key(),
+                "Key with special chars should round-trip correctly through XML escaping");
+    }
+
+    @Test
+    @Order(28)
+    void sdkListObjects_maxKeysReflectedInResponse() throws Exception {
+        // The XML builder hardcodes <MaxKeys>1000</MaxKeys> regardless of the
+        // client's max-keys query parameter. The SDK should see the requested value.
+        when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
+                .thenReturn(List.of());
+
+        ListObjectsV2Response response = s3.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET)
+                        .maxKeys(5)
+                        .build()
+        );
+
+        assertEquals(5, response.maxKeys(),
+                "MaxKeys in response should reflect the client's requested value, not hardcoded 1000");
+    }
+
     // ===================== MULTIPART UPLOAD =====================
 
     @Test
-    @Order(26)
+    @Order(29)
     void sdkCreateMultipartUpload_returnsUploadId() throws Exception {
         when(mockStorage.initiateMultipartUpload(BUCKET, KEY)).thenReturn("upload-id-xyz");
 
@@ -581,7 +643,7 @@ class S3Test {
     }
 
     @Test
-    @Order(27)
+    @Order(30)
     void sdkCreateMultipartUpload_delegatesCorrectBucketAndKey_toStorageService() throws Exception {
         when(mockStorage.initiateMultipartUpload(anyString(), anyString())).thenReturn("upload-id-xyz");
 
@@ -594,7 +656,7 @@ class S3Test {
     }
 
     @Test
-    @Order(28)
+    @Order(31)
     void sdkUploadPart_completesWithoutException() throws Exception {
         byte[] partData = new byte[5 * 1024 * 1024]; 
         doAnswer(invocation -> {
@@ -619,7 +681,7 @@ class S3Test {
     }
 
     @Test
-    @Order(29)
+    @Order(32)
     void sdkUploadPart_delegatesCorrectArgs_toStorageService() throws Exception {
         byte[] partData = new byte[5 * 1024 * 1024];
         doAnswer(invocation -> {
@@ -643,7 +705,7 @@ class S3Test {
     }
 
     @Test
-    @Order(30)
+    @Order(33)
     void sdkCompleteMultipartUpload_completesWithoutException() throws Exception {
         when(mockStorage.completeMultipartUpload(eq(BUCKET), eq(KEY), eq("upload-id-xyz"), anyList()))
                                 .thenReturn(MultipartUploadResult.success());
@@ -665,7 +727,7 @@ class S3Test {
     }
 
     @Test
-    @Order(31)
+    @Order(34)
     void sdkCompleteMultipartUpload_delegatesCorrectUploadIdAndParts_toStorageService() throws Exception {
         when(mockStorage.completeMultipartUpload(anyString(), anyString(), anyString(), anyList()))
                                 .thenReturn(MultipartUploadResult.success());
@@ -690,7 +752,7 @@ class S3Test {
     }
 
     @Test
-    @Order(32)
+    @Order(35)
     void sdkAbortMultipartUpload_returns204_noException() throws Exception {
         when(mockStorage.abortMultipartUpload(anyString(), anyString(), anyString()))
                 .thenReturn(MultipartUploadResult.success());
@@ -705,7 +767,7 @@ class S3Test {
     }
 
     @Test
-    @Order(33)
+    @Order(36)
     void sdkAbortMultipartUpload_delegatesCorrectArgs_toStorageService() throws Exception {
         when(mockStorage.abortMultipartUpload(anyString(), anyString(), anyString()))
                 .thenReturn(MultipartUploadResult.success());
@@ -721,7 +783,7 @@ class S3Test {
     // ===================== MULTIPART FULL LIFECYCLE =====================
 
     @Test
-    @Order(34)
+    @Order(37)
     void sdkMultipartLifecycle_initiateUploadCompleteThenGet() throws Exception {
         String uploadId = "lifecycle-upload-id";
         byte[] part1 = new byte[5 * 1024 * 1024];

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/gateway/S3Test.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/gateway/S3Test.java
@@ -565,10 +565,10 @@ class S3Test {
     @Test
     @Order(26)
     void sdkListObjects_keysDoNotIncludeBucketPrefix() throws Exception {
-        // StorageWorkerService returns keys as "bucket/key" from the storage layer.
-        // The XML builder should strip the bucket prefix so clients see just "key".
+        // StorageWorkerService strips the "bucket/" prefix at the adapter layer.
+        // Verify the gateway correctly passes through bucket-relative keys.
         List<ObjectSummary> summaries = List.of(
-                new ObjectSummary(BUCKET + "/photo.jpg", 100L, "2025-01-01T00:00:00Z")
+                new ObjectSummary("photo.jpg", 100L, "2025-01-01T00:00:00Z")
         );
         when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
                 .thenReturn(summaries);

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/AckingFakeStorageNodeServer.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/AckingFakeStorageNodeServer.java
@@ -55,8 +55,14 @@ final class AckingFakeStorageNodeServer extends FakeStorageNodeServer {
                         deleteData(partition, m.bucket() + "/" + m.key());
                         sendAck(m.requestID(), m.sender());
                     }
-                    case Message.CreateBucketMessage m -> sendAck(m.requestID(), m.sender());
-                    case Message.DeleteBucketMessage m -> sendAck(m.requestID(), m.sender());
+                    case Message.CreateBucketMessage m -> {
+                        addBucket(m.bucket());
+                        sendAck(m.requestID(), m.sender());
+                    }
+                    case Message.DeleteBucketMessage m -> {
+                        removeBucket(m.bucket());
+                        sendAck(m.requestID(), m.sender());
+                    }
                     default -> {}
                 }
             });

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/FakeStorageNodeServer.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/FakeStorageNodeServer.java
@@ -126,6 +126,10 @@ public class FakeStorageNodeServer implements Closeable {
         }
         try {
             String bucket = ctx.pathParam("bucket");
+            if (!buckets.contains(bucket)) {
+                ctx.status(404);
+                return;
+            }
             String prefix = ctx.queryParam("prefix");
             String maxKeysParam = ctx.queryParam("maxKeys");
             int maxKeys = (maxKeysParam != null) ? Integer.parseInt(maxKeysParam) : 1000;

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/FakeStorageNodeServer.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/FakeStorageNodeServer.java
@@ -7,7 +7,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,6 +22,7 @@ public class FakeStorageNodeServer implements Closeable {
 
     private final Javalin app;
     private final Map<String, byte[]> store = new ConcurrentHashMap<>();
+    private final Set<String> buckets = ConcurrentHashMap.newKeySet();
     private volatile boolean enabled = true;
 
     private final Logger logger = LogManager.getLogger(FakeStorageNodeServer.class);
@@ -33,6 +36,9 @@ public class FakeStorageNodeServer implements Closeable {
             config.routes.put("/store/{partition}/<key>", this::handlePut);
             config.routes.get("/store/{partition}/<key>", this::handleGet);
             config.routes.delete("/store/{partition}/<key>", this::handleDelete);
+
+            config.routes.head("/bucket/{bucket}", this::handleHeadBucket);
+            config.routes.get("/bucket/{bucket}", this::handleListObjects);
         });
 
         app.start(0); // OS picks a free port
@@ -102,6 +108,54 @@ public class FakeStorageNodeServer implements Closeable {
             logger.error("Error in fake DELETE", e);
             ctx.status(500).result("ERROR");
         }
+    }
+
+    private void handleHeadBucket(Context ctx) {
+        if (!enabled) {
+            ctx.status(503).result("NODE_DISABLED");
+            return;
+        }
+        String bucket = ctx.pathParam("bucket");
+        ctx.status(buckets.contains(bucket) ? 200 : 404);
+    }
+
+    private void handleListObjects(Context ctx) {
+        if (!enabled) {
+            ctx.status(503).result("NODE_DISABLED");
+            return;
+        }
+        try {
+            String bucket = ctx.pathParam("bucket");
+            String prefix = ctx.queryParam("prefix");
+            String maxKeysParam = ctx.queryParam("maxKeys");
+            int maxKeys = (maxKeysParam != null) ? Integer.parseInt(maxKeysParam) : 1000;
+
+            String scanPrefix = bucket + "/" + (prefix == null ? "" : prefix);
+
+            String body = store.keySet().stream()
+                    .map(k -> k.substring(k.indexOf('|') + 1))
+                    .filter(k -> k.startsWith(scanPrefix))
+                    .distinct()
+                    .sorted()
+                    .limit(maxKeys)
+                    .map(k -> "{\"key\":\"" + k.replace("\\", "\\\\").replace("\"", "\\\"") + "\"}")
+                    .collect(Collectors.joining(",", "[", "]"));
+
+            ctx.status(200).header("Content-Type", "application/json").result(body);
+        } catch (NumberFormatException e) {
+            ctx.status(400).result("Invalid maxKeys parameter");
+        } catch (Exception e) {
+            logger.error("Error in fake list objects", e);
+            ctx.status(500).result("ERROR");
+        }
+    }
+
+    void addBucket(String bucket) {
+        buckets.add(bucket);
+    }
+
+    void removeBucket(String bucket) {
+        buckets.remove(bucket);
     }
 
     private static String mapKey(int partition, String key) {

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
@@ -611,6 +611,98 @@ public class StorageWorkerApiTest {
     }
 
     // -------------------------------------------------------------------------
+    // bucketExists / listObjects tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void bucketExists_returnsTrueAfterCreate() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+        List<AckingFakeStorageNodeServer> beNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) beNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = beNodes.stream().map(AckingFakeStorageNodeServer::address).toList();
+
+        MetadataClient client = createConfiguredClient(set);
+        StorageWorker w = new StorageWorker(client, new CommitCoordinator(bus, 0));
+        try {
+            assertTrue(w.createBucket(UUID.randomUUID(), "exists-bucket"), "createBucket should succeed");
+            assertTrue(w.bucketExists("exists-bucket"), "bucketExists should be true after create");
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : beNodes) n.close();
+        }
+    }
+
+    @Test
+    void bucketExists_returnsFalseForNonExistentBucket() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+        List<AckingFakeStorageNodeServer> beNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) beNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = beNodes.stream().map(AckingFakeStorageNodeServer::address).toList();
+
+        MetadataClient client = createConfiguredClient(set);
+        StorageWorker w = new StorageWorker(client, new CommitCoordinator(bus, 0));
+        try {
+            assertFalse(w.bucketExists("never-created"), "bucketExists should be false");
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : beNodes) n.close();
+        }
+    }
+
+    @Test
+    void listObjects_returnsEmptyForEmptyBucket() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+        List<AckingFakeStorageNodeServer> loNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) loNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = loNodes.stream().map(AckingFakeStorageNodeServer::address).toList();
+
+        MetadataClient client = createConfiguredClient(set);
+        StorageWorker w = new StorageWorker(client, new CommitCoordinator(bus, 0));
+        try {
+            assertTrue(w.createBucket(UUID.randomUUID(), "empty-bucket"));
+            List<StorageWorker.ObjectInfo> objects = w.listObjects("empty-bucket", "", 1000);
+            assertNotNull(objects);
+            assertTrue(objects.isEmpty(), "expected empty list, got: " + objects);
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : loNodes) n.close();
+        }
+    }
+
+    @Test
+    void listObjects_returnsStoredObjects() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+        List<AckingFakeStorageNodeServer> loNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) loNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = loNodes.stream().map(AckingFakeStorageNodeServer::address).toList();
+
+        MetadataClient client = createConfiguredClient(set);
+        StorageWorker w = new StorageWorker(client, new CommitCoordinator(bus, 0));
+        try {
+            assertTrue(w.createBucket(UUID.randomUUID(), "list-bucket"));
+
+            byte[] data = randomBytes(1024);
+            assertTrue(w.put(UUID.randomUUID(), "list-bucket", "alpha", data.length,
+                    new ByteArrayInputStream(data)));
+            assertTrue(w.put(UUID.randomUUID(), "list-bucket", "beta", data.length,
+                    new ByteArrayInputStream(data)));
+            assertTrue(w.put(UUID.randomUUID(), "list-bucket", "gamma", data.length,
+                    new ByteArrayInputStream(data)));
+
+            List<StorageWorker.ObjectInfo> objects = w.listObjects("list-bucket", "", 1000);
+            List<String> keys = objects.stream().map(StorageWorker.ObjectInfo::key).sorted().toList();
+            assertEquals(List.of("list-bucket/alpha", "list-bucket/beta", "list-bucket/gamma"), keys);
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : loNodes) n.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
@@ -702,6 +702,81 @@ public class StorageWorkerApiTest {
         }
     }
 
+    /**
+     * Proves that parseObjectListJson silently swallows parse errors.
+     * The method currently returns an empty list on malformed JSON with NO
+     * logging — making corrupt responses indistinguishable from empty buckets.
+     * This test locks in the current fallback behavior so the fix can safely
+     * add logging without breaking the return contract.
+     */
+    @Test
+    void parseObjectListJson_returnsEmptyOnMalformedInput() throws Exception {
+        // Access the private static method via reflection
+        java.lang.reflect.Method method = StorageWorker.class.getDeclaredMethod(
+                "parseObjectListJson", String.class);
+        method.setAccessible(true);
+
+        // Malformed JSON — not valid JSON at all
+        @SuppressWarnings("unchecked")
+        List<StorageWorker.ObjectInfo> result1 =
+                (List<StorageWorker.ObjectInfo>) method.invoke(null, "THIS IS NOT JSON!!!");
+        assertNotNull(result1, "Should return non-null on malformed input");
+        assertTrue(result1.isEmpty(), "Should return empty list on malformed JSON, got: " + result1);
+
+        // Truncated JSON — partial array
+        @SuppressWarnings("unchecked")
+        List<StorageWorker.ObjectInfo> result2 =
+                (List<StorageWorker.ObjectInfo>) method.invoke(null, "[{\"key\":\"test");
+        assertNotNull(result2, "Should return non-null on truncated input");
+        assertTrue(result2.isEmpty(), "Should return empty list on truncated JSON, got: " + result2);
+
+        // Null input
+        @SuppressWarnings("unchecked")
+        List<StorageWorker.ObjectInfo> result3 =
+                (List<StorageWorker.ObjectInfo>) method.invoke(null, (String) null);
+        assertNotNull(result3, "Should return non-null on null input");
+        assertTrue(result3.isEmpty(), "Should return empty list on null input");
+
+        // Empty string
+        @SuppressWarnings("unchecked")
+        List<StorageWorker.ObjectInfo> result4 =
+                (List<StorageWorker.ObjectInfo>) method.invoke(null, "");
+        assertNotNull(result4, "Should return non-null on empty input");
+        assertTrue(result4.isEmpty(), "Should return empty list on empty input");
+    }
+
+    /**
+     * Proves that FakeStorageNodeServer returns 200 for list-objects
+     * on a bucket that was never created. In production, storage nodes would
+     * return 404 for a non-existent bucket. The fake server should do the same
+     * to prevent false-positive tests.
+     *
+     * After fixing FakeStorageNodeServer.handleListObjects() to check
+     * bucket existence, this test should still pass (empty list returned)
+     * because StorageWorker.listObjects() treats 404 the same as empty.
+     */
+    @Test
+    void listObjects_returnsEmptyForNonExistentBucket() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+        List<AckingFakeStorageNodeServer> loNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) loNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = loNodes.stream().map(AckingFakeStorageNodeServer::address).toList();
+
+        MetadataClient client = createConfiguredClient(set);
+        StorageWorker w = new StorageWorker(client, new CommitCoordinator(bus, 0));
+        try {
+            // Do NOT create the bucket — go straight to listing
+            List<StorageWorker.ObjectInfo> objects = w.listObjects("never-created-bucket", "", 1000);
+            assertNotNull(objects, "Should return non-null even for non-existent bucket");
+            assertTrue(objects.isEmpty(),
+                    "Should return empty list for non-existent bucket, got: " + objects);
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : loNodes) n.close();
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -9,6 +9,7 @@ import java.nio.channels.Channels;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -387,16 +388,31 @@ public class StorageNodeServerV2 {
             String maxKeysParam = ctx.queryParam("maxKeys");
             int maxKeys = (maxKeysParam != null) ? Integer.parseInt(maxKeysParam) : 1000;
 
+            if (maxKeys < 0) {
+                ctx.status(400).result("maxKeys must be non-negative");
+                return;
+            }
+
+            // Return 404 if the bucket doesn't exist (matches HEAD semantics and S3 behavior)
+            if (!storageNode.bucketExists(bucket)) {
+                ctx.status(404);
+                return;
+            }
+
             // Prefix scan: bucket + "/" ensures we only get objects inside this bucket
             String scanPrefix = bucket + "/";
             if (prefix != null && !prefix.isEmpty()) {
                 scanPrefix = bucket + "/" + prefix;
             }
 
-            var items = storageNode.listItemsInBucket(scanPrefix)
-                    .limit(maxKeys)
-                    .map(m -> "{\"key\":\"" + escapeJson(m.key()) + "\"}")
-                    .toList();
+            // try-with-resources closes the underlying RocksDB iterator
+            List<String> items;
+            try (var stream = storageNode.listItemsInBucket(scanPrefix)) {
+                items = stream
+                        .limit(maxKeys)
+                        .map(m -> "{\"key\":\"" + escapeJson(m.key()) + "\"}")
+                        .toList();
+            }
 
             ctx.status(200)
                .header("Content-Type", "application/json")

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -594,17 +594,15 @@ public class StorageNodeServerV2 {
             }
 
             // try-with-resources closes the underlying RocksDB iterator
-            List<String> items;
+            List<Map<String, String>> items;
             try (var stream = storageNode.listItemsInBucket(scanPrefix)) {
                 items = stream
                         .limit(maxKeys)
-                        .map(m -> "{\"key\":\"" + escapeJson(m.key()) + "\"}")
+                        .map(m -> Map.of("key", m.key()))
                         .toList();
             }
 
-            ctx.status(200)
-               .header("Content-Type", "application/json")
-               .result("[" + String.join(",", items) + "]");
+            ctx.status(200).json(items);
         } catch (NumberFormatException e) {
             ctx.status(400).result("Invalid maxKeys parameter");
         } catch (Exception e) {
@@ -613,10 +611,7 @@ public class StorageNodeServerV2 {
         }
     }
 
-    /** Minimal JSON string escaping for keys. */
-    private static String escapeJson(String s) {
-        return s.replace("\\", "\\\\").replace("\"", "\\\"");
-    }
+
 
     public void start() {
         repairWorkerPool.start();

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -26,6 +26,7 @@ import com.github.koop.common.metadata.MetadataClient;
 import com.github.koop.common.metadata.PartitionSpreadConfiguration;
 import com.github.koop.common.pubsub.PubSubClient;
 import com.github.koop.storagenode.db.Database;
+import com.github.koop.storagenode.db.Metadata;
 
 import io.javalin.Javalin;
 import io.javalin.http.Context;
@@ -366,6 +367,53 @@ public class StorageNodeServerV2 {
         return bucket + "/" + key;
     }
 
+    // ─── Bucket query handlers ────────────────────────────────────────────────
+
+    private void handleHeadBucket(Context ctx) {
+        try {
+            String bucket = ctx.pathParam("bucket");
+            boolean exists = storageNode.bucketExists(bucket);
+            ctx.status(exists ? 200 : 404);
+        } catch (Exception e) {
+            logger.error("Error handling HEAD /bucket", e);
+            ctx.status(500);
+        }
+    }
+
+    private void handleListObjects(Context ctx) {
+        try {
+            String bucket = ctx.pathParam("bucket");
+            String prefix = ctx.queryParam("prefix");
+            String maxKeysParam = ctx.queryParam("maxKeys");
+            int maxKeys = (maxKeysParam != null) ? Integer.parseInt(maxKeysParam) : 1000;
+
+            // Prefix scan: bucket + "/" ensures we only get objects inside this bucket
+            String scanPrefix = bucket + "/";
+            if (prefix != null && !prefix.isEmpty()) {
+                scanPrefix = bucket + "/" + prefix;
+            }
+
+            var items = storageNode.listItemsInBucket(scanPrefix)
+                    .limit(maxKeys)
+                    .map(m -> "{\"key\":\"" + escapeJson(m.key()) + "\"}")
+                    .toList();
+
+            ctx.status(200)
+               .header("Content-Type", "application/json")
+               .result("[" + String.join(",", items) + "]");
+        } catch (NumberFormatException e) {
+            ctx.status(400).result("Invalid maxKeys parameter");
+        } catch (Exception e) {
+            logger.error("Error handling GET /bucket", e);
+            ctx.status(500);
+        }
+    }
+
+    /** Minimal JSON string escaping for keys. */
+    private static String escapeJson(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
     public void start() {
         if (metadataClient != null) {
             this.currentEsConfig = metadataClient.get(ErasureSetConfiguration.class);
@@ -389,6 +437,10 @@ public class StorageNodeServerV2 {
             config.http.maxRequestSize = 100_000_000L;
             config.routes.put("/store/{partition}/{bucket}/<key>", this::handlePut);
             config.routes.get("/store/{partition}/{bucket}/<key>", this::handleGet);
+
+            // Bucket-level query endpoints (read-only, no PubSub needed)
+            config.routes.head("/bucket/{bucket}", this::handleHeadBucket);
+            config.routes.get("/bucket/{bucket}", this::handleListObjects);
         });
 
         app.start(port);

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -35,6 +35,7 @@ import com.github.koop.common.pubsub.CommitTopics;
 import com.github.koop.common.pubsub.PubSubClient;
 import com.github.koop.storagenode.db.Database;
 import com.github.koop.storagenode.db.Metadata;
+import com.github.koop.storagenode.db.TombstoneFileVersion;
 
 import io.javalin.Javalin;
 import io.javalin.http.Context;
@@ -597,6 +598,11 @@ public class StorageNodeServerV2 {
             List<Map<String, String>> items;
             try (var stream = storageNode.listItemsInBucket(scanPrefix)) {
                 items = stream
+                        .filter(m -> {
+                            var versions = m.versions();
+                            if (versions == null || versions.isEmpty()) return false;
+                            return !(versions.getLast() instanceof TombstoneFileVersion);
+                        })
                         .limit(maxKeys)
                         .map(m -> Map.of("key", m.key()))
                         .toList();

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -619,4 +619,48 @@ class StorageNodeServerV2Test {
         assertTrue(resp.body().contains(fullKey2));
         assertFalse(resp.body().contains(otherKey), "Should not include objects from other buckets");
     }
+
+    @Test
+    void testListObjects_excludesDeletedObjects() throws Exception {
+        int partition = 16;
+        String bucket = "tombstone-list-bucket";
+        String key1 = "alive.txt";
+        String key2 = "deleted.txt";
+        String fullKey1 = bucket + "/" + key1;
+        String fullKey2 = bucket + "/" + key2;
+
+        // Create bucket
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-ts-create", getDummySender()), 1200L);
+
+        // PUT + commit both objects
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, fullKey1, "req-ts-1"))
+                .PUT(HttpRequest.BodyPublishers.ofString("data1")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage(bucket, key1, "req-ts-1", getDummySender()), 1201L);
+
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, fullKey2, "req-ts-2"))
+                .PUT(HttpRequest.BodyPublishers.ofString("data2")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage(bucket, key2, "req-ts-2", getDummySender()), 1202L);
+
+        // Delete the second object (writes a tombstone)
+        server.processSequencerMessage(partition,
+                new Message.DeleteMessage(bucket, key2, "req-ts-del", getDummySender()), 1203L);
+
+        // List objects — deleted key should NOT appear
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .GET()
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode());
+        assertTrue(resp.body().contains(fullKey1), "Living object should still appear in listing");
+        assertFalse(resp.body().contains(fullKey2),
+                "Deleted (tombstoned) object should NOT appear in listing, but got: " + resp.body());
+    }
 }

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -507,6 +507,10 @@ class StorageNodeServerV2Test {
         String fullKey1 = bucket + "/" + key1;
         String fullKey2 = bucket + "/" + key2;
 
+        // Create bucket first so that GET /bucket/{bucket} doesn't 404
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-list-create", getDummySender()), 899L);
+
         // PUT + commit two objects
         http.send(HttpRequest.newBuilder()
                 .uri(storeUriWithReq(partition, fullKey1, "req-list-1"))
@@ -536,6 +540,10 @@ class StorageNodeServerV2Test {
     void testListObjects_respectsMaxKeysParam() throws Exception {
         int partition = 14;
         String bucket = "maxkeys-bucket";
+
+        // Create bucket first
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-mk-create", getDummySender()), 999L);
 
         // Commit three objects
         for (int i = 1; i <= 3; i++) {
@@ -568,6 +576,12 @@ class StorageNodeServerV2Test {
     void testListObjects_onlyReturnsObjectsMatchingPrefix() throws Exception {
         int partition = 15;
         String bucket = "prefix-bucket";
+
+        // Create both buckets first
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-pf-create", getDummySender()), 1099L);
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage("other-bucket", "req-pf-other-create", getDummySender()), 1098L);
 
         // Two objects in "prefix-bucket", one in "other-bucket"
         String fullKey1 = bucket + "/alpha";

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -30,6 +30,7 @@ import io.javalin.Javalin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class StorageNodeServerV2Test {
 
@@ -401,5 +402,195 @@ class StorageNodeServerV2Test {
         assertEquals(dataStr, getResp2.body(), "GET should return the correctly materialized data");
         assertEquals("500", getResp2.headers().firstValue("X-Koop-Version").orElse(""), 
             "The version headers should match the initial sequencer commit");
+    }
+
+    // ─── Bucket query endpoint helpers ────────────────────────────────────────
+
+    private URI bucketUri(String bucket) {
+        return URI.create("http://localhost:" + port + "/bucket/" + bucket);
+    }
+
+    private URI bucketUriWithParams(String bucket, String prefix, Integer maxKeys) {
+        StringBuilder sb = new StringBuilder("http://localhost:" + port + "/bucket/" + bucket);
+        String sep = "?";
+        if (prefix != null) { sb.append(sep).append("prefix=").append(prefix); sep = "&"; }
+        if (maxKeys != null) { sb.append(sep).append("maxKeys=").append(maxKeys); }
+        return URI.create(sb.toString());
+    }
+
+    // ─── HeadBucket tests ─────────────────────────────────────────────────────
+
+    @Test
+    void testHeadBucket_returnsNotFoundWhenBucketDoesNotExist() throws Exception {
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri("no-such-bucket"))
+                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<Void> resp = http.send(req, HttpResponse.BodyHandlers.discarding());
+        assertEquals(404, resp.statusCode(), "HEAD should return 404 for non-existent bucket");
+    }
+
+    @Test
+    void testHeadBucket_returnsOkAfterBucketCreated() throws Exception {
+        int partition = 10;
+        String bucket = "head-test-bucket";
+
+        // Create bucket via sequencer message
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-head-create", getDummySender()), 600L);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<Void> resp = http.send(req, HttpResponse.BodyHandlers.discarding());
+        assertEquals(200, resp.statusCode(), "HEAD should return 200 after bucket is created");
+    }
+
+    @Test
+    void testHeadBucket_returnsNotFoundAfterBucketDeleted() throws Exception {
+        int partition = 11;
+        String bucket = "head-delete-bucket";
+
+        // Create then delete
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-hd-create", getDummySender()), 700L);
+        server.processSequencerMessage(partition,
+                new Message.DeleteBucketMessage(bucket, "req-hd-delete", getDummySender()), 701L);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<Void> resp = http.send(req, HttpResponse.BodyHandlers.discarding());
+        assertEquals(404, resp.statusCode(), "HEAD should return 404 after bucket is deleted");
+    }
+
+    // ─── ListObjects tests ────────────────────────────────────────────────────
+
+    @Test
+    void testListObjects_returnsEmptyListWhenNoObjects() throws Exception {
+        int partition = 12;
+        String bucket = "empty-list-bucket";
+
+        server.processSequencerMessage(partition,
+                new Message.CreateBucketMessage(bucket, "req-empty-list", getDummySender()), 800L);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .GET()
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode());
+        assertEquals("application/json", resp.headers().firstValue("Content-Type").orElse(""));
+        assertEquals("[]", resp.body().trim());
+    }
+
+    @Test
+    void testListObjects_returnsObjectsInBucket() throws Exception {
+        int partition = 13;
+        String bucket = "list-bucket";
+        String key1 = "file1.txt";
+        String key2 = "file2.txt";
+        String fullKey1 = bucket + "/" + key1;
+        String fullKey2 = bucket + "/" + key2;
+
+        // PUT + commit two objects
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, fullKey1, "req-list-1"))
+                .PUT(HttpRequest.BodyPublishers.ofString("data1")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage(bucket, key1, "req-list-1", getDummySender()), 900L);
+
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, fullKey2, "req-list-2"))
+                .PUT(HttpRequest.BodyPublishers.ofString("data2")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage(bucket, key2, "req-list-2", getDummySender()), 901L);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .GET()
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode());
+        assertTrue(resp.body().contains(fullKey1), "Response should contain " + fullKey1);
+        assertTrue(resp.body().contains(fullKey2), "Response should contain " + fullKey2);
+    }
+
+    @Test
+    void testListObjects_respectsMaxKeysParam() throws Exception {
+        int partition = 14;
+        String bucket = "maxkeys-bucket";
+
+        // Commit three objects
+        for (int i = 1; i <= 3; i++) {
+            String key = "obj" + i;
+            String fullKey = bucket + "/" + key;
+            String reqId = "req-mk-" + i;
+            http.send(HttpRequest.newBuilder()
+                    .uri(storeUriWithReq(partition, fullKey, reqId))
+                    .PUT(HttpRequest.BodyPublishers.ofString("data" + i)).build(),
+                    HttpResponse.BodyHandlers.ofString());
+            server.processSequencerMessage(partition,
+                    new Message.FileCommitMessage(bucket, key, reqId, getDummySender()), 1000L + i);
+        }
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUriWithParams(bucket, null, 1))
+                .GET()
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode());
+
+        // Count how many "key" entries appear. With maxKeys=1, should be exactly 1 object.
+        // Simple check: split by "key" field separator
+        String body = resp.body();
+        long objectCount = body.chars().filter(ch -> ch == '{').count();
+        assertEquals(1, objectCount, "maxKeys=1 should return exactly 1 object, got: " + body);
+    }
+
+    @Test
+    void testListObjects_onlyReturnsObjectsMatchingPrefix() throws Exception {
+        int partition = 15;
+        String bucket = "prefix-bucket";
+
+        // Two objects in "prefix-bucket", one in "other-bucket"
+        String fullKey1 = bucket + "/alpha";
+        String fullKey2 = bucket + "/beta";
+        String otherKey = "other-bucket/gamma";
+
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, fullKey1, "req-pf-1"))
+                .PUT(HttpRequest.BodyPublishers.ofString("a")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage(bucket, "alpha", "req-pf-1", getDummySender()), 1100L);
+
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, fullKey2, "req-pf-2"))
+                .PUT(HttpRequest.BodyPublishers.ofString("b")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage(bucket, "beta", "req-pf-2", getDummySender()), 1101L);
+
+        http.send(HttpRequest.newBuilder()
+                .uri(storeUriWithReq(partition, otherKey, "req-pf-3"))
+                .PUT(HttpRequest.BodyPublishers.ofString("c")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(partition,
+                new Message.FileCommitMessage("other-bucket", "gamma", "req-pf-3", getDummySender()), 1102L);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .GET()
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode());
+        assertTrue(resp.body().contains(fullKey1));
+        assertTrue(resp.body().contains(fullKey2));
+        assertFalse(resp.body().contains(otherKey), "Should not include objects from other buckets");
     }
 }

--- a/system-tests/src/test/java/koop/S3GatewayE2EIT.java
+++ b/system-tests/src/test/java/koop/S3GatewayE2EIT.java
@@ -690,10 +690,7 @@ public class S3GatewayE2EIT {
         s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
 
         byte[] data = "x".getBytes(StandardCharsets.UTF_8);
-        // Single-segment keys: the gateway's /{bucket}/{key} route is non-greedy,
-        // so multi-segment keys (e.g. "logs/jan.txt") don't match. Use a prefix
-        // pattern that lives entirely within one path segment.
-        for (String k : List.of("logs-jan.txt", "logs-feb.txt", "images-cat.png")) {
+        for (String k : List.of("logs/jan.txt", "logs/feb.txt", "images/cat.png")) {
             s3.putObject(
                     PutObjectRequest.builder().bucket(bucket).key(k)
                             .contentLength((long) data.length).build(),
@@ -701,13 +698,13 @@ public class S3GatewayE2EIT {
         }
 
         ListObjectsV2Response resp = s3.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(bucket).prefix("logs-").build());
+                ListObjectsV2Request.builder().bucket(bucket).prefix("logs/").build());
 
         assertEquals(2, resp.keyCount(),
-                "prefix=logs- should match exactly 2 keys, got: " + resp.contents());
+                "prefix=logs/ should match exactly 2 keys, got: " + resp.contents());
         for (S3Object o : resp.contents()) {
-            assertTrue(o.key().contains("logs-"),
-                    "every returned key should contain 'logs-' prefix, got: " + o.key());
+            assertTrue(o.key().contains("logs/"),
+                    "every returned key should be under logs/ prefix, got: " + o.key());
         }
         log("[E2E] ListObjects prefix PASSED");
     }

--- a/system-tests/src/test/java/koop/S3GatewayE2EIT.java
+++ b/system-tests/src/test/java/koop/S3GatewayE2EIT.java
@@ -566,6 +566,152 @@ public class S3GatewayE2EIT {
         log("[E2E] Large multipart upload test PASSED");
     }
 
+    // =====================================================================
+    // TEST: HeadBucket on existing bucket returns 200
+    // =====================================================================
+    @Test
+    void e2e_createBucket_thenHeadBucket_returns200() {
+        log("[E2E] CreateBucket → HeadBucket 200 test");
+
+        String bucket = "head-exists-" + System.nanoTime();
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        log("[E2E] CreateBucket completed");
+
+        assertDoesNotThrow(() ->
+                s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build()),
+                "HeadBucket on existing bucket should not throw");
+        log("[E2E] HeadBucket → 200 PASSED");
+    }
+
+    // =====================================================================
+    // TEST: HeadBucket on missing bucket returns 404 NoSuchBucket
+    // =====================================================================
+    @Test
+    void e2e_headBucket_onMissingBucket_returns404() {
+        log("[E2E] HeadBucket missing → 404 test");
+
+        NoSuchBucketException ex = assertThrows(NoSuchBucketException.class, () ->
+                s3.headBucket(HeadBucketRequest.builder()
+                        .bucket("never-created-" + System.nanoTime())
+                        .build())
+        );
+        assertEquals(404, ex.statusCode(),
+                "HeadBucket on missing bucket should return 404");
+        log("[E2E] HeadBucket missing → 404 PASSED");
+    }
+
+    // =====================================================================
+    // TEST: CreateBucket → DeleteBucket → HeadBucket returns 404
+    // =====================================================================
+    @Test
+    void e2e_createThenDeleteBucket_headReturns404() {
+        log("[E2E] Create → Delete → HeadBucket 404 test");
+
+        String bucket = "lifecycle-" + System.nanoTime();
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        assertDoesNotThrow(() ->
+                s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build()),
+                "HeadBucket should succeed after create");
+
+        s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+        log("[E2E] DeleteBucket completed");
+
+        NoSuchBucketException ex = assertThrows(NoSuchBucketException.class, () ->
+                s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build())
+        );
+        assertEquals(404, ex.statusCode(),
+                "HeadBucket after DeleteBucket should return 404");
+        log("[E2E] Bucket lifecycle PASSED");
+    }
+
+    // =====================================================================
+    // TEST: ListObjectsV2 on empty bucket returns 0 contents
+    // =====================================================================
+    @Test
+    void e2e_listObjects_emptyBucket_returnsZeroContents() {
+        log("[E2E] ListObjects empty bucket test");
+
+        String bucket = "empty-list-" + System.nanoTime();
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+
+        ListObjectsV2Response resp = s3.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(bucket).build());
+
+        assertEquals(0, resp.keyCount(), "empty bucket should have keyCount=0");
+        assertTrue(resp.contents().isEmpty(), "empty bucket should have no Contents");
+        log("[E2E] Empty list PASSED");
+    }
+
+    // =====================================================================
+    // TEST: PUT objects → ListObjectsV2 returns their keys
+    // =====================================================================
+    @Test
+    void e2e_putObjects_thenListObjects_returnsKeys() {
+        log("[E2E] PUT → ListObjects returns keys test");
+
+        String bucket = "list-keys-" + System.nanoTime();
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+
+        byte[] data = "list-test".getBytes(StandardCharsets.UTF_8);
+        List<String> keys = List.of("alpha.txt", "beta.txt", "gamma.txt");
+        for (String k : keys) {
+            s3.putObject(
+                    PutObjectRequest.builder().bucket(bucket).key(k)
+                            .contentLength((long) data.length).build(),
+                    RequestBody.fromBytes(data));
+        }
+        log("[E2E] PUT " + keys.size() + " objects completed");
+
+        ListObjectsV2Response resp = s3.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(bucket).build());
+
+        assertEquals(keys.size(), resp.keyCount(),
+                "keyCount should match number of PUTs");
+        List<String> returnedKeys = new ArrayList<>(resp.contents().stream().map(S3Object::key).toList());
+        Collections.sort(returnedKeys);
+        // The storage layer stores keys as "bucket/key"; assert each user-visible key is in the returned list.
+        for (String k : keys) {
+            String storedKey = bucket + "/" + k;
+            assertTrue(returnedKeys.contains(storedKey) || returnedKeys.contains(k),
+                    "ListObjects should return key " + k + " (looked for '" + k
+                            + "' or '" + storedKey + "' in " + returnedKeys + ")");
+        }
+        log("[E2E] ListObjects keys PASSED");
+    }
+
+    // =====================================================================
+    // TEST: ListObjectsV2 with prefix only returns matching keys
+    // =====================================================================
+    @Test
+    void e2e_listObjects_withPrefix_filtersResults() {
+        log("[E2E] ListObjects with prefix test");
+
+        String bucket = "prefix-list-" + System.nanoTime();
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+
+        byte[] data = "x".getBytes(StandardCharsets.UTF_8);
+        // Single-segment keys: the gateway's /{bucket}/{key} route is non-greedy,
+        // so multi-segment keys (e.g. "logs/jan.txt") don't match. Use a prefix
+        // pattern that lives entirely within one path segment.
+        for (String k : List.of("logs-jan.txt", "logs-feb.txt", "images-cat.png")) {
+            s3.putObject(
+                    PutObjectRequest.builder().bucket(bucket).key(k)
+                            .contentLength((long) data.length).build(),
+                    RequestBody.fromBytes(data));
+        }
+
+        ListObjectsV2Response resp = s3.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(bucket).prefix("logs-").build());
+
+        assertEquals(2, resp.keyCount(),
+                "prefix=logs- should match exactly 2 keys, got: " + resp.contents());
+        for (S3Object o : resp.contents()) {
+            assertTrue(o.key().contains("logs-"),
+                    "every returned key should contain 'logs-' prefix, got: " + o.key());
+        }
+        log("[E2E] ListObjects prefix PASSED");
+    }
+
     // -------------------------------------------------------
     // Helpers
     // -------------------------------------------------------

--- a/system-tests/src/test/java/koop/S3GatewayE2EIT.java
+++ b/system-tests/src/test/java/koop/S3GatewayE2EIT.java
@@ -576,10 +576,14 @@ public class S3GatewayE2EIT {
         s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
         log("[E2E] CreateBucket completed");
 
-        assertDoesNotThrow(() ->
-                s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build()),
-                "HeadBucket on existing bucket should not throw");
-        log("[E2E] HeadBucket → 200 PASSED");
+        try {
+            assertDoesNotThrow(() ->
+                    s3.headBucket(HeadBucketRequest.builder().bucket(bucket).build()),
+                    "HeadBucket on existing bucket should not throw");
+            log("[E2E] HeadBucket → 200 PASSED");
+        } finally {
+            s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+        }
     }
 
     // =====================================================================
@@ -633,12 +637,16 @@ public class S3GatewayE2EIT {
         String bucket = "empty-list-" + System.nanoTime();
         s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
 
-        ListObjectsV2Response resp = s3.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(bucket).build());
+        try {
+            ListObjectsV2Response resp = s3.listObjectsV2(
+                    ListObjectsV2Request.builder().bucket(bucket).build());
 
-        assertEquals(0, resp.keyCount(), "empty bucket should have keyCount=0");
-        assertTrue(resp.contents().isEmpty(), "empty bucket should have no Contents");
-        log("[E2E] Empty list PASSED");
+            assertEquals(0, resp.keyCount(), "empty bucket should have keyCount=0");
+            assertTrue(resp.contents().isEmpty(), "empty bucket should have no Contents");
+            log("[E2E] Empty list PASSED");
+        } finally {
+            s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+        }
     }
 
     // =====================================================================
@@ -653,29 +661,36 @@ public class S3GatewayE2EIT {
 
         byte[] data = "list-test".getBytes(StandardCharsets.UTF_8);
         List<String> keys = List.of("alpha.txt", "beta.txt", "gamma.txt");
-        for (String k : keys) {
-            s3.putObject(
-                    PutObjectRequest.builder().bucket(bucket).key(k)
-                            .contentLength((long) data.length).build(),
-                    RequestBody.fromBytes(data));
-        }
-        log("[E2E] PUT " + keys.size() + " objects completed");
+        try {
+            for (String k : keys) {
+                s3.putObject(
+                        PutObjectRequest.builder().bucket(bucket).key(k)
+                                .contentLength((long) data.length).build(),
+                        RequestBody.fromBytes(data));
+            }
+            log("[E2E] PUT " + keys.size() + " objects completed");
 
-        ListObjectsV2Response resp = s3.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(bucket).build());
+            ListObjectsV2Response resp = s3.listObjectsV2(
+                    ListObjectsV2Request.builder().bucket(bucket).build());
 
-        assertEquals(keys.size(), resp.keyCount(),
-                "keyCount should match number of PUTs");
-        List<String> returnedKeys = new ArrayList<>(resp.contents().stream().map(S3Object::key).toList());
-        Collections.sort(returnedKeys);
-        // The storage layer stores keys as "bucket/key"; assert each user-visible key is in the returned list.
-        for (String k : keys) {
-            String storedKey = bucket + "/" + k;
-            assertTrue(returnedKeys.contains(storedKey) || returnedKeys.contains(k),
-                    "ListObjects should return key " + k + " (looked for '" + k
-                            + "' or '" + storedKey + "' in " + returnedKeys + ")");
+            assertEquals(keys.size(), resp.keyCount(),
+                    "keyCount should match number of PUTs");
+            List<String> returnedKeys = new ArrayList<>(resp.contents().stream().map(S3Object::key).toList());
+            Collections.sort(returnedKeys);
+            // The storage layer stores keys as "bucket/key"; assert each user-visible key is in the returned list.
+            for (String k : keys) {
+                String storedKey = bucket + "/" + k;
+                assertTrue(returnedKeys.contains(storedKey) || returnedKeys.contains(k),
+                        "ListObjects should return key " + k + " (looked for '" + k
+                                + "' or '" + storedKey + "' in " + returnedKeys + ")");
+            }
+            log("[E2E] ListObjects keys PASSED");
+        } finally {
+            for (String k : keys) {
+                try { s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(k).build()); } catch (Exception ignored) {}
+            }
+            s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
         }
-        log("[E2E] ListObjects keys PASSED");
     }
 
     // =====================================================================
@@ -689,23 +704,31 @@ public class S3GatewayE2EIT {
         s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
 
         byte[] data = "x".getBytes(StandardCharsets.UTF_8);
-        for (String k : List.of("logs/jan.txt", "logs/feb.txt", "images/cat.png")) {
-            s3.putObject(
-                    PutObjectRequest.builder().bucket(bucket).key(k)
-                            .contentLength((long) data.length).build(),
-                    RequestBody.fromBytes(data));
-        }
+        List<String> allKeys = List.of("logs/jan.txt", "logs/feb.txt", "images/cat.png");
+        try {
+            for (String k : allKeys) {
+                s3.putObject(
+                        PutObjectRequest.builder().bucket(bucket).key(k)
+                                .contentLength((long) data.length).build(),
+                        RequestBody.fromBytes(data));
+            }
 
-        ListObjectsV2Response resp = s3.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(bucket).prefix("logs/").build());
+            ListObjectsV2Response resp = s3.listObjectsV2(
+                    ListObjectsV2Request.builder().bucket(bucket).prefix("logs/").build());
 
-        assertEquals(2, resp.keyCount(),
-                "prefix=logs/ should match exactly 2 keys, got: " + resp.contents());
-        for (S3Object o : resp.contents()) {
-            assertTrue(o.key().contains("logs/"),
-                    "every returned key should be under logs/ prefix, got: " + o.key());
+            assertEquals(2, resp.keyCount(),
+                    "prefix=logs/ should match exactly 2 keys, got: " + resp.contents());
+            for (S3Object o : resp.contents()) {
+                assertTrue(o.key().contains("logs/"),
+                        "every returned key should be under logs/ prefix, got: " + o.key());
+            }
+            log("[E2E] ListObjects prefix PASSED");
+        } finally {
+            for (String k : allKeys) {
+                try { s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(k).build()); } catch (Exception ignored) {}
+            }
+            s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
         }
-        log("[E2E] ListObjects prefix PASSED");
     }
 
     // -------------------------------------------------------


### PR DESCRIPTION
This pull request implements full support for bucket existence checks and object listing in both the storage worker and the test infrastructure. It adds real implementations for `bucketExists` and `listObjects` in the storage worker, updates the test storage node server to support these APIs, and introduces comprehensive tests for these new capabilities. Additionally, it improves S3 compatibility and error handling in the XML response builder.

**Storage Worker and Gateway Enhancements:**

- Implemented `bucketExists` and `listObjects` methods in `StorageWorker`, including HTTP fan-out and robust JSON parsing logic for object listings.
- Updated `StorageWorkerService` to provide real implementations for `createBucket`, `deleteBucket`, `listObjects`, and `bucketExists`, replacing previous unimplemented stubs.

**Test Infrastructure Improvements:**

- Enhanced `FakeStorageNodeServer` and `AckingFakeStorageNodeServer` to track buckets, support the `/bucket/{bucket}` HEAD and GET APIs, and properly manage bucket creation and deletion. [[1]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfR25) [[2]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfR39-R41) [[3]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfR113-R160) [[4]](diffhunk://#diff-6f36e9578a44b7d2d2697853ff0864dac360ed21784a28048869ea30f8d36f01L58-R65)
- Added comprehensive tests for `bucketExists` and `listObjects` to `StorageWorkerApiTest`, covering both positive and negative cases.

**S3 Compatibility and Error Handling:**

- Improved S3 compatibility in `buildListObjectsXml` by ensuring `LastModified` is always a valid ISO-8601 timestamp, defaulting to the epoch if missing.

**Other:**

- Minor import and setup adjustments for test classes. [[1]](diffhunk://#diff-3096a66ecd87a366ec29ff0ad11ce8f9a01bcd82414195da768f43dc04de10dfR10-R12) [[2]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968R29)