### PR TITLE
persist repair queue

### DIFF
--- a/storage-node/src/main/java/com/github/koop/storagenode/RepairOperation.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/RepairOperation.java
@@ -1,5 +1,7 @@
 package com.github.koop.storagenode;
 
+import java.io.*;
+
 /**
  * Represents a single repair task to be processed by the {@link RepairWorkerPool}.
  *
@@ -11,4 +13,31 @@ package com.github.koop.storagenode;
  *                  location when writing the recovered shard to disk.
  */
 public record RepairOperation(String blobKey, long seqOffset, String requestId) {
+
+    public byte[] serialize() {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream dos = new DataOutputStream(baos)) {
+            dos.writeUTF(blobKey);
+            dos.writeLong(seqOffset);
+            dos.writeBoolean(requestId != null);
+            if (requestId != null) {
+                dos.writeUTF(requestId);
+            }
+            dos.flush();
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static RepairOperation deserialize(byte[] data) {
+        try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(data))) {
+            String blobKey = dis.readUTF();
+            long seqOffset = dis.readLong();
+            String requestId = dis.readBoolean() ? dis.readUTF() : null;
+            return new RepairOperation(blobKey, seqOffset, requestId);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }

--- a/storage-node/src/main/java/com/github/koop/storagenode/RepairWorkerPool.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/RepairWorkerPool.java
@@ -1,10 +1,11 @@
 package com.github.koop.storagenode;
 
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
@@ -12,100 +13,60 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Manages a pool of virtual-thread workers that process {@link RepairOperation}s
- * with debounced, last-writer-wins compaction.
+ * from a persistent {@link RocksDbRepairQueue}.
  *
- * <p>When the same key is enqueued multiple times before execution, only the
- * operation with the highest {@link RepairOperation#seqOffset()} is retained.
- * An incoming operation whose seqOffset is less than or equal to the pending
- * operation's seqOffset is silently discarded (at-least-once idempotency).
+ * <p>A polling loop periodically scans the queue for pending operations.
+ * Operations whose blobKey has an active write (per {@link WriteTracker}) are
+ * deferred to the next poll cycle. Successfully completed operations are
+ * deleted from the queue; failed operations remain for automatic retry.
  *
- * <p>A short delay between enqueue and execution lets rapid sequential updates
- * compact and gives in-progress writes time to finish before a repair fires.
- *
- * <p>Actual repair work is delegated to a {@link BlobRepairStrategy} supplied
- * at construction time, keeping this class free of direct dependencies on
- * {@link StorageNodeV2} or HTTP clients.
+ * <p>On node startup, no distinct recovery phase is needed — the poller
+ * naturally resumes processing any operations left in the queue from a
+ * previous run.
  */
-public class RepairWorkerPool implements RepairQueue {
+public class RepairWorkerPool {
 
     private static final Logger logger = LogManager.getLogger(RepairWorkerPool.class);
 
     static final long REPAIR_DELAY_MS = 2_000;
 
-    private final ConcurrentHashMap<String, RepairOperation> pendingOperations = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledFutures = new ConcurrentHashMap<>();
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
-            Thread.ofVirtual().name("repair-scheduler").factory());
+    private final RocksDbRepairQueue queue;
+    private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+    private final ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("repair-poller").factory());
     private final ExecutorService workerPool = Executors.newVirtualThreadPerTaskExecutor();
     private final WriteTracker writeTracker;
     private final BlobRepairStrategy repairStrategy;
     private final long repairDelayMs;
     private volatile boolean running;
 
-    public RepairWorkerPool(WriteTracker writeTracker, BlobRepairStrategy repairStrategy) {
-        this(writeTracker, REPAIR_DELAY_MS, repairStrategy);
+    public RepairWorkerPool(RocksDbRepairQueue queue, WriteTracker writeTracker,
+                            BlobRepairStrategy repairStrategy) {
+        this(queue, writeTracker, REPAIR_DELAY_MS, repairStrategy);
     }
 
-    /** Package-private constructor for tests that need a shorter dispatch delay. */
-    RepairWorkerPool(WriteTracker writeTracker, long repairDelayMs, BlobRepairStrategy repairStrategy) {
+    RepairWorkerPool(RocksDbRepairQueue queue, WriteTracker writeTracker,
+                     long repairDelayMs, BlobRepairStrategy repairStrategy) {
+        this.queue = queue;
         this.writeTracker = writeTracker;
         this.repairDelayMs = repairDelayMs;
         this.repairStrategy = repairStrategy;
         this.running = false;
     }
 
-    /**
-     * Enqueues a repair operation with debounced, last-writer-wins compaction.
-     *
-     * <p>If a pending repair already exists for the same key with an equal or higher
-     * seqOffset, the incoming operation is discarded. If the incoming seqOffset is
-     * strictly higher, the pending operation is replaced and the scheduled execution
-     * is reset.
-     */
-    @Override
-    public void enqueue(RepairOperation operation) {
-        if (operation == null) {
-            return;
-        }
-        String key = operation.blobKey();
-
-        RepairOperation winner = pendingOperations.merge(key, operation, (existing, incoming) ->
-                incoming.seqOffset() > existing.seqOffset() ? incoming : existing);
-
-        if (winner != operation) {
-            // Existing operation has equal or higher seqOffset — discard incoming
-            logger.debug("Discarding stale repair: key={}, incoming={}, existing={}",
-                    key, operation.seqOffset(), winner.seqOffset());
-            return;
-        }
-
-        // Incoming won — cancel the previously scheduled future (if any) and reschedule
-        ScheduledFuture<?> old = scheduledFutures.put(key,
-                scheduler.schedule(() -> dispatchRepair(key), repairDelayMs, TimeUnit.MILLISECONDS));
-        if (old != null) {
-            old.cancel(false);
-        }
-        logger.debug("Enqueued repair: key={}, seqOffset={}", key, operation.seqOffset());
-    }
-
-    /**
-     * Starts the worker pool. Must be called before any repair operations execute.
-     */
     public void start() {
         if (running) {
             throw new IllegalStateException("RepairWorkerPool is already running");
         }
         running = true;
-        logger.info("RepairWorkerPool started (virtual-thread workers)");
+        long period = Math.max(repairDelayMs, 1);
+        poller.scheduleWithFixedDelay(this::pollAndDispatch, period, period, TimeUnit.MILLISECONDS);
+        logger.info("RepairWorkerPool started (persistent queue, virtual-thread workers)");
     }
 
-    /**
-     * Gracefully shuts down the worker pool and scheduler. Waits up to 10 seconds
-     * for in-flight operations to complete.
-     */
     public void shutdown() {
         running = false;
-        scheduler.shutdownNow();
+        poller.shutdownNow();
         workerPool.shutdownNow();
         try {
             if (!workerPool.awaitTermination(10, TimeUnit.SECONDS)) {
@@ -115,51 +76,57 @@ public class RepairWorkerPool implements RepairQueue {
             Thread.currentThread().interrupt();
             logger.warn("Interrupted while waiting for RepairWorkerPool shutdown");
         }
-        logger.info("RepairWorkerPool shut down. Remaining pending: {}", pendingOperations.size());
+        logger.info("RepairWorkerPool shut down. Remaining pending: {}", queue.size());
     }
 
-    /**
-     * Returns the current number of operations waiting to be dispatched.
-     */
     public int pendingCount() {
-        return pendingOperations.size();
+        return queue.size();
     }
 
-    /**
-     * Returns whether the worker pool is currently running.
-     */
     public boolean isRunning() {
         return running;
     }
 
-    private void dispatchRepair(String key) {
-        scheduledFutures.remove(key);
-        RepairOperation op = pendingOperations.remove(key);
-        if (op == null) {
-            return;
-        }
+    private void pollAndDispatch() {
         if (!running) {
-            logger.debug("Pool not running; dropping repair for key={}", key);
             return;
         }
-        if (writeTracker.isActive(key)) {
-            // Write in progress — re-enqueue so it retries after the blob lands
-            logger.debug("Deferring repair for key={}: write in progress", key);
-            enqueue(op);
-            return;
+        try {
+            List<RocksDbRepairQueue.RepairEntry> entries = queue.pollAll(inFlight);
+            for (var entry : entries) {
+                RepairOperation op = entry.operation();
+
+                if (writeTracker.isActive(op.blobKey())) {
+                    logger.debug("Deferring repair for key={}: write in progress", op.blobKey());
+                    continue;
+                }
+
+                if (!inFlight.add(op.blobKey())) {
+                    continue;
+                }
+
+                final var e = entry;
+                workerPool.submit(() -> executeRepair(e));
+            }
+        } catch (Exception e) {
+            logger.error("Error during repair poll cycle", e);
         }
-        workerPool.submit(() -> executeRepair(op));
     }
 
-    /**
-     * Executes a single repair operation by delegating to the configured
-     * {@link BlobRepairStrategy}.
-     */
-    void executeRepair(RepairOperation operation) {
-        if (repairStrategy != null) {
-            repairStrategy.repair(operation);
-        } else {
-            logger.warn("No repair strategy configured; skipping repair for key={}", operation.blobKey());
+    private void executeRepair(RocksDbRepairQueue.RepairEntry entry) {
+        RepairOperation op = entry.operation();
+        try {
+            if (repairStrategy != null) {
+                repairStrategy.repair(op);
+            } else {
+                logger.warn("No repair strategy configured; skipping repair for key={}",
+                        op.blobKey());
+            }
+            queue.remove(entry.rocksKey(), op.blobKey());
+        } catch (Exception e) {
+            logger.error("Repair failed for key={}, will retry", op.blobKey(), e);
+        } finally {
+            inFlight.remove(op.blobKey());
         }
     }
 }

--- a/storage-node/src/main/java/com/github/koop/storagenode/RepairWorkerPool.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/RepairWorkerPool.java
@@ -29,6 +29,7 @@ public class RepairWorkerPool {
     private static final Logger logger = LogManager.getLogger(RepairWorkerPool.class);
 
     static final long REPAIR_DELAY_MS = 2_000;
+    private static final int MAX_IN_FLIGHT = 32;
 
     private final RocksDbRepairQueue queue;
     private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
@@ -94,6 +95,10 @@ public class RepairWorkerPool {
         try {
             List<RocksDbRepairQueue.RepairEntry> entries = queue.pollAll(inFlight);
             for (var entry : entries) {
+                if (inFlight.size() >= MAX_IN_FLIGHT) {
+                    break;
+                }
+
                 RepairOperation op = entry.operation();
 
                 if (writeTracker.isActive(op.blobKey())) {

--- a/storage-node/src/main/java/com/github/koop/storagenode/RocksDbRepairQueue.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/RocksDbRepairQueue.java
@@ -88,30 +88,40 @@ public class RocksDbRepairQueue implements RepairQueue {
         }
 
         String blobKey = operation.blobKey();
-        PendingEntry existing = blobKeyIndex.get(blobKey);
-        if (existing != null && existing.seqOffset() >= operation.seqOffset()) {
-            logger.debug("Discarding stale repair: key={}, incoming={}, existing={}",
-                    blobKey, operation.seqOffset(), existing.seqOffset());
-            return;
-        }
-
         byte[] rocksKey = longToBytes(sequence.incrementAndGet());
         byte[] value = operation.serialize();
 
-        try {
-            strategy.putRepairEntry(rocksKey, value);
-            PendingEntry old = blobKeyIndex.put(blobKey,
-                    new PendingEntry(rocksKey, operation.seqOffset()));
-            if (old != null) {
-                try {
-                    strategy.deleteRepairEntry(old.rocksKey());
-                } catch (Exception e) {
-                    logger.warn("Failed to delete superseded repair entry for key={}", blobKey, e);
-                }
+        // Atomic check-and-update: holds the map lock for this key so concurrent
+        // enqueues for the same blobKey are serialized.
+        final byte[][] toDelete = {null};
+        PendingEntry result = blobKeyIndex.compute(blobKey, (k, existing) -> {
+            if (existing != null && existing.seqOffset() >= operation.seqOffset()) {
+                return existing;
             }
+            try {
+                strategy.putRepairEntry(rocksKey, value);
+            } catch (Exception e) {
+                logger.error("Failed to persist repair operation for key={}", blobKey, e);
+                return existing;
+            }
+            if (existing != null) {
+                toDelete[0] = existing.rocksKey();
+            }
+            return new PendingEntry(rocksKey, operation.seqOffset());
+        });
+
+        if (toDelete[0] != null) {
+            try {
+                strategy.deleteRepairEntry(toDelete[0]);
+            } catch (Exception e) {
+                logger.warn("Failed to delete superseded repair entry for key={}", blobKey, e);
+            }
+        }
+
+        if (result != null && Arrays.equals(result.rocksKey(), rocksKey)) {
             logger.debug("Enqueued repair: key={}, seqOffset={}", blobKey, operation.seqOffset());
-        } catch (Exception e) {
-            logger.error("Failed to persist repair operation for key={}", blobKey, e);
+        } else {
+            logger.debug("Discarding stale repair: key={}, incoming={}", blobKey, operation.seqOffset());
         }
     }
 

--- a/storage-node/src/main/java/com/github/koop/storagenode/RocksDbRepairQueue.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/RocksDbRepairQueue.java
@@ -1,0 +1,167 @@
+package com.github.koop.storagenode;
+
+import com.github.koop.storagenode.db.RocksDbStorageStrategy;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.rocksdb.RocksIterator;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RocksDbRepairQueue implements RepairQueue {
+
+    private static final Logger logger = LogManager.getLogger(RocksDbRepairQueue.class);
+
+    private final RocksDbStorageStrategy strategy;
+    private final AtomicLong sequence;
+    private final ConcurrentHashMap<String, PendingEntry> blobKeyIndex;
+
+    private record PendingEntry(byte[] rocksKey, long seqOffset) {}
+
+    public RocksDbRepairQueue(RocksDbStorageStrategy strategy) {
+        this.strategy = strategy;
+        this.blobKeyIndex = new ConcurrentHashMap<>();
+        this.sequence = new AtomicLong(0);
+        rebuildIndex();
+    }
+
+    private void rebuildIndex() {
+        try (RocksIterator it = strategy.newRepairQueueIterator()) {
+            it.seekToFirst();
+            long maxSeq = 0;
+            while (it.isValid()) {
+                byte[] key = it.key();
+                long seq = ByteBuffer.wrap(key).getLong();
+                if (seq > maxSeq) {
+                    maxSeq = seq;
+                }
+
+                RepairOperation op;
+                try {
+                    op = RepairOperation.deserialize(it.value());
+                } catch (Exception e) {
+                    logger.warn("Skipping corrupt repair queue entry at seq={}", seq, e);
+                    try {
+                        strategy.deleteRepairEntry(key);
+                    } catch (Exception de) {
+                        logger.warn("Failed to delete corrupt entry", de);
+                    }
+                    it.next();
+                    continue;
+                }
+
+                PendingEntry existing = blobKeyIndex.get(op.blobKey());
+                if (existing == null || op.seqOffset() > existing.seqOffset()) {
+                    if (existing != null) {
+                        try {
+                            strategy.deleteRepairEntry(existing.rocksKey());
+                        } catch (Exception e) {
+                            logger.warn("Failed to clean up duplicate repair entry during rebuild", e);
+                        }
+                    }
+                    blobKeyIndex.put(op.blobKey(), new PendingEntry(key.clone(), op.seqOffset()));
+                } else {
+                    try {
+                        strategy.deleteRepairEntry(key);
+                    } catch (Exception e) {
+                        logger.warn("Failed to clean up stale repair entry during rebuild", e);
+                    }
+                }
+
+                it.next();
+            }
+            sequence.set(maxSeq);
+            logger.info("RepairQueue rebuilt: {} pending operations, next sequence={}",
+                    blobKeyIndex.size(), maxSeq + 1);
+        }
+    }
+
+    @Override
+    public void enqueue(RepairOperation operation) {
+        if (operation == null) {
+            return;
+        }
+
+        String blobKey = operation.blobKey();
+        PendingEntry existing = blobKeyIndex.get(blobKey);
+        if (existing != null && existing.seqOffset() >= operation.seqOffset()) {
+            logger.debug("Discarding stale repair: key={}, incoming={}, existing={}",
+                    blobKey, operation.seqOffset(), existing.seqOffset());
+            return;
+        }
+
+        byte[] rocksKey = longToBytes(sequence.incrementAndGet());
+        byte[] value = operation.serialize();
+
+        try {
+            strategy.putRepairEntry(rocksKey, value);
+            PendingEntry old = blobKeyIndex.put(blobKey,
+                    new PendingEntry(rocksKey, operation.seqOffset()));
+            if (old != null) {
+                try {
+                    strategy.deleteRepairEntry(old.rocksKey());
+                } catch (Exception e) {
+                    logger.warn("Failed to delete superseded repair entry for key={}", blobKey, e);
+                }
+            }
+            logger.debug("Enqueued repair: key={}, seqOffset={}", blobKey, operation.seqOffset());
+        } catch (Exception e) {
+            logger.error("Failed to persist repair operation for key={}", blobKey, e);
+        }
+    }
+
+    /**
+     * Returns all pending repair entries whose blobKey is not in the exclude set,
+     * in chronological order (oldest first).
+     */
+    public List<RepairEntry> pollAll(Set<String> excludeBlobKeys) {
+        List<RepairEntry> entries = new ArrayList<>();
+        try (RocksIterator it = strategy.newRepairQueueIterator()) {
+            it.seekToFirst();
+            while (it.isValid()) {
+                RepairOperation op;
+                try {
+                    op = RepairOperation.deserialize(it.value());
+                } catch (Exception e) {
+                    it.next();
+                    continue;
+                }
+                if (!excludeBlobKeys.contains(op.blobKey())) {
+                    entries.add(new RepairEntry(it.key().clone(), op));
+                }
+                it.next();
+            }
+        }
+        return entries;
+    }
+
+    public void remove(byte[] rocksKey, String blobKey) {
+        try {
+            strategy.deleteRepairEntry(rocksKey);
+            blobKeyIndex.computeIfPresent(blobKey, (k, existing) -> {
+                if (Arrays.equals(existing.rocksKey(), rocksKey)) {
+                    return null;
+                }
+                return existing;
+            });
+            logger.debug("Removed completed repair: key={}", blobKey);
+        } catch (Exception e) {
+            logger.error("Failed to remove repair entry for key={}", blobKey, e);
+        }
+    }
+
+    public int size() {
+        return blobKeyIndex.size();
+    }
+
+    private static byte[] longToBytes(long value) {
+        return ByteBuffer.allocate(8).putLong(value).array();
+    }
+
+    public record RepairEntry(byte[] rocksKey, RepairOperation operation) {}
+}

--- a/storage-node/src/main/java/com/github/koop/storagenode/RocksDbRepairQueue.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/RocksDbRepairQueue.java
@@ -36,6 +36,16 @@ public class RocksDbRepairQueue implements RepairQueue {
             long maxSeq = 0;
             while (it.isValid()) {
                 byte[] key = it.key();
+                if (key.length != 8) {
+                    logger.warn("Skipping repair queue entry with invalid key length={}", key.length);
+                    try {
+                        strategy.deleteRepairEntry(key);
+                    } catch (Exception de) {
+                        logger.warn("Failed to delete invalid-length entry", de);
+                    }
+                    it.next();
+                    continue;
+                }
                 long seq = ByteBuffer.wrap(key).getLong();
                 if (seq > maxSeq) {
                     maxSeq = seq;
@@ -126,7 +136,8 @@ public class RocksDbRepairQueue implements RepairQueue {
     }
 
     /**
-     * Returns all pending repair entries whose blobKey is not in the exclude set,
+     * Returns pending repair entries whose blobKey is not in the exclude set
+     * and whose rocksKey matches the current index entry (filtering stale rows),
      * in chronological order (oldest first).
      */
     public List<RepairEntry> pollAll(Set<String> excludeBlobKeys) {
@@ -134,6 +145,7 @@ public class RocksDbRepairQueue implements RepairQueue {
         try (RocksIterator it = strategy.newRepairQueueIterator()) {
             it.seekToFirst();
             while (it.isValid()) {
+                byte[] rocksKey = it.key();
                 RepairOperation op;
                 try {
                     op = RepairOperation.deserialize(it.value());
@@ -141,8 +153,20 @@ public class RocksDbRepairQueue implements RepairQueue {
                     it.next();
                     continue;
                 }
-                if (!excludeBlobKeys.contains(op.blobKey())) {
-                    entries.add(new RepairEntry(it.key().clone(), op));
+                if (excludeBlobKeys.contains(op.blobKey())) {
+                    it.next();
+                    continue;
+                }
+                PendingEntry current = blobKeyIndex.get(op.blobKey());
+                if (current != null && Arrays.equals(current.rocksKey(), rocksKey)) {
+                    entries.add(new RepairEntry(rocksKey.clone(), op));
+                } else if (current == null) {
+                    // Orphaned row — delete it
+                    try {
+                        strategy.deleteRepairEntry(rocksKey);
+                    } catch (Exception e) {
+                        logger.warn("Failed to delete orphaned repair entry for key={}", op.blobKey(), e);
+                    }
                 }
                 it.next();
             }

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -46,6 +46,7 @@ public class StorageNodeServerV2 {
     private final MetadataClient metadataClient;
     private final PubSubClient pubSubClient;
     private final RepairWorkerPool repairWorkerPool;
+    private final RocksDbRepairQueue repairQueue;
     private final Database db;
 
     private Javalin app;
@@ -63,14 +64,13 @@ public class StorageNodeServerV2 {
     private static final Logger logger = LogManager.getLogger(StorageNodeServerV2.class);
 
     public StorageNodeServerV2(int port, String ip, Database db, Path dir, MetadataClient metadataClient,
-            PubSubClient pubSubClient) {
+            PubSubClient pubSubClient, RocksDbRepairQueue repairQueue) {
         this.port = port;
         this.ip = ip;
         this.db = db;
+        this.repairQueue = repairQueue;
         WriteTracker writeTracker = new WriteTracker();
-        // Lambda captures 'this' — storageNode/config are dereferenced at call time,
-        // not at construction time, so there is no circular dependency.
-        this.repairWorkerPool = new RepairWorkerPool(writeTracker, this::repairBlob);
+        this.repairWorkerPool = new RepairWorkerPool(repairQueue, writeTracker, this::repairBlob);
         this.storageNode = new StorageNodeV2(db, dir, writeTracker);
         this.metadataClient = metadataClient;
         this.pubSubClient = pubSubClient;
@@ -96,9 +96,12 @@ public class StorageNodeServerV2 {
         }
 
         Database db;
+        RocksDbRepairQueue repairQueue;
         try {
             String dbPath = storagePath.resolve("rocksdb").toString();
-            db = new Database(new RocksDbStorageStrategy(dbPath));
+            RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(dbPath);
+            repairQueue = new RocksDbRepairQueue(strategy);
+            db = new Database(strategy);
             logger.info("RocksDB opened at {}", dbPath);
         } catch (Exception e) {
             e.printStackTrace(System.err);
@@ -134,7 +137,7 @@ public class StorageNodeServerV2 {
         logger.info(">>> PubSubClient started");
 
 
-        StorageNodeServerV2 server = new StorageNodeServerV2(port, ip, db, storagePath, metadataClient, pubSubClient);
+        StorageNodeServerV2 server = new StorageNodeServerV2(port, ip, db, storagePath, metadataClient, pubSubClient, repairQueue);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             logger.info("Shutting down server...");
@@ -353,7 +356,7 @@ public class StorageNodeServerV2 {
                     String fullKey = buildKey(m.bucket(), m.key());
                     boolean materialized = storageNode.commit(partition, fullKey, m.requestID(), seqNumber);
                     if (!materialized) {
-                        repairWorkerPool.enqueue(new RepairOperation(fullKey, seqNumber, m.requestID()));
+                        repairQueue.enqueue(new RepairOperation(fullKey, seqNumber, m.requestID()));
                     }
                     requestId = m.requestID();
                     logger.info("Committed file: {}", fullKey);

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -708,6 +708,12 @@ public class StorageNodeServerV2 {
         partitionExecutors.values().forEach(ExecutorService::shutdownNow);
         partitionExecutors.clear();
 
+        try {
+            db.close();
+        } catch (Exception e) {
+            logger.error("Failed to close database", e);
+        }
+
         logger.info("StorageNodeServerV2 stopped");
     }
 

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -142,6 +142,11 @@ public class StorageNodeServerV2 {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             logger.info("Shutting down server...");
             server.stop();
+            try {
+                db.close();
+            } catch (Exception e) {
+                logger.error("Failed to close database", e);
+            }
         }));
 
         server.start();
@@ -707,12 +712,6 @@ public class StorageNodeServerV2 {
 
         partitionExecutors.values().forEach(ExecutorService::shutdownNow);
         partitionExecutors.clear();
-
-        try {
-            db.close();
-        } catch (Exception e) {
-            logger.error("Failed to close database", e);
-        }
 
         logger.info("StorageNodeServerV2 stopped");
     }

--- a/storage-node/src/main/java/com/github/koop/storagenode/db/RocksDbStorageStrategy.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/db/RocksDbStorageStrategy.java
@@ -17,6 +17,7 @@ public class RocksDbStorageStrategy implements StorageStrategy {
     private final ColumnFamilyHandle metaHandle;
     private final ColumnFamilyHandle bucketsHandle;
     private final ColumnFamilyHandle uncommittedHandle;
+    private final ColumnFamilyHandle repairQueueHandle;
     private volatile boolean closed = false;
 
     public RocksDbStorageStrategy(String dbPath) throws RocksDBException {
@@ -27,7 +28,8 @@ public class RocksDbStorageStrategy implements StorageStrategy {
                 new ColumnFamilyDescriptor("op_log".getBytes(StandardCharsets.UTF_8), new ColumnFamilyOptions()),
                 new ColumnFamilyDescriptor("metadata".getBytes(StandardCharsets.UTF_8), new ColumnFamilyOptions()),
                 new ColumnFamilyDescriptor("buckets".getBytes(StandardCharsets.UTF_8), new ColumnFamilyOptions()),
-                new ColumnFamilyDescriptor("uncommitted_writes".getBytes(StandardCharsets.UTF_8), new ColumnFamilyOptions()));
+                new ColumnFamilyDescriptor("uncommitted_writes".getBytes(StandardCharsets.UTF_8), new ColumnFamilyOptions()),
+                new ColumnFamilyDescriptor("repair_queue".getBytes(StandardCharsets.UTF_8), new ColumnFamilyOptions()));
 
         handles = new ArrayList<>();
         try (DBOptions options = new DBOptions()
@@ -40,6 +42,7 @@ public class RocksDbStorageStrategy implements StorageStrategy {
             metaHandle        = handles.get(2);
             bucketsHandle     = handles.get(3);
             uncommittedHandle = handles.get(4);
+            repairQueueHandle = handles.get(5);
         }
     }
 
@@ -55,6 +58,20 @@ public class RocksDbStorageStrategy implements StorageStrategy {
         byte[] key = requestId.getBytes(StandardCharsets.UTF_8);
         byte[] val = ByteBuffer.allocate(8).putLong(timestamp).array();
         txnDb.put(uncommittedHandle, key, val);
+    }
+
+    // --- Repair Queue ---
+
+    public void putRepairEntry(byte[] key, byte[] value) throws RocksDBException {
+        txnDb.put(repairQueueHandle, key, value);
+    }
+
+    public void deleteRepairEntry(byte[] key) throws RocksDBException {
+        txnDb.delete(repairQueueHandle, key);
+    }
+
+    public RocksIterator newRepairQueueIterator() {
+        return txnDb.newIterator(repairQueueHandle);
     }
 
     @Override

--- a/storage-node/src/test/java/com/github/koop/storagenode/RepairWorkerPoolTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/RepairWorkerPoolTest.java
@@ -387,4 +387,68 @@ class RepairWorkerPoolTest {
         // Should not throw — just logs a warning
         assertEquals(0, pool.pendingCount());
     }
+
+    // -------------------------------------------------------------------------
+    // Crash recovery: persistent queue survives pool restart cycles
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testPersistentQueueSurvivesMultipleRestartCycles() throws Exception {
+        List<RepairOperation> executed = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch latch = new CountDownLatch(1);
+        String dbPath = tempDir.resolve("restart-db").toAbsolutePath().toString();
+
+        // --- Cycle 1: enqueue while pool is NOT running, then shut down ---
+        RocksDbStorageStrategy strategy1 = new RocksDbStorageStrategy(dbPath);
+        RocksDbRepairQueue queue1 = new RocksDbRepairQueue(strategy1);
+        // Pool never started — simulate node being offline while repairs arrive
+        queue1.enqueue(new RepairOperation("key-a", 10L, "req-a"));
+        queue1.enqueue(new RepairOperation("key-b", 20L, "req-b"));
+        assertEquals(2, queue1.size());
+        strategy1.close();
+
+        // --- Cycle 2: restart, pool runs but shuts down before completing ---
+        RocksDbStorageStrategy strategy2 = new RocksDbStorageStrategy(dbPath);
+        RocksDbRepairQueue queue2 = new RocksDbRepairQueue(strategy2);
+        assertEquals(2, queue2.size(), "Both operations should survive restart");
+
+        // Start pool with a strategy that blocks until interrupted — simulates crash mid-repair
+        CountDownLatch blockRepair = new CountDownLatch(1);
+        RepairWorkerPool pool2 = new RepairWorkerPool(queue2, new WriteTracker(), 1L, op -> {
+            try {
+                blockRepair.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("simulated crash", e);
+            }
+        });
+        pool2.start();
+        Thread.sleep(100); // let poll dispatch
+        // Shut down before repairs complete — simulates crash
+        pool2.shutdown();
+        strategy2.close();
+
+        // --- Cycle 3: final restart — operations should still be in the queue ---
+        RocksDbStorageStrategy strategy3 = new RocksDbStorageStrategy(dbPath);
+        RocksDbRepairQueue queue3 = new RocksDbRepairQueue(strategy3);
+        assertEquals(2, queue3.size(), "Operations should survive a second restart");
+
+        RepairWorkerPool pool3 = new RepairWorkerPool(queue3, new WriteTracker(), 1L, op -> {
+            executed.add(op);
+            if (executed.size() == 2) latch.countDown();
+        });
+        pool3.start();
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "Both operations should eventually execute");
+        assertEquals(2, executed.size());
+        assertTrue(executed.stream().anyMatch(op -> op.blobKey().equals("key-a") && op.seqOffset() == 10L));
+        assertTrue(executed.stream().anyMatch(op -> op.blobKey().equals("key-b") && op.seqOffset() == 20L));
+
+        // Queue should be drained after successful processing
+        Thread.sleep(100);
+        assertEquals(0, queue3.size(), "Queue should be empty after successful repairs");
+
+        pool3.shutdown();
+        strategy3.close();
+    }
 }

--- a/storage-node/src/test/java/com/github/koop/storagenode/RepairWorkerPoolTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/RepairWorkerPoolTest.java
@@ -2,24 +2,39 @@ package com.github.koop.storagenode;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import com.github.koop.storagenode.db.RocksDbStorageStrategy;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class RepairWorkerPoolTest {
 
     private RepairWorkerPool pool;
+    private RocksDbRepairQueue queue;
+
+    @TempDir
+    Path tempDir;
 
     @AfterEach
     void tearDown() {
         if (pool != null) {
             pool.shutdown();
         }
+    }
+
+    private RocksDbRepairQueue createQueue() throws Exception {
+        RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(
+                tempDir.resolve("db-" + System.nanoTime()).toAbsolutePath().toString());
+        queue = new RocksDbRepairQueue(strategy);
+        return queue;
     }
 
     // -------------------------------------------------------------------------
@@ -31,15 +46,16 @@ class RepairWorkerPoolTest {
         List<RepairOperation> executed = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch latch = new CountDownLatch(3);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 0L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 1L, op -> {
             executed.add(op);
             latch.countDown();
         });
         pool.start();
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
-        pool.enqueue(new RepairOperation("key2", 2L, null));
-        pool.enqueue(new RepairOperation("key3", 3L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key2", 2L, null));
+        queue.enqueue(new RepairOperation("key3", 3L, null));
 
         assertTrue(latch.await(5, TimeUnit.SECONDS), "All 3 operations should be processed");
         assertEquals(3, executed.size());
@@ -52,7 +68,8 @@ class RepairWorkerPoolTest {
         CountDownLatch release = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(numOps);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 0L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 1L, op -> {
             inProgress.countDown();
             try {
                 release.await(5, TimeUnit.SECONDS);
@@ -64,7 +81,7 @@ class RepairWorkerPoolTest {
         pool.start();
 
         for (int i = 0; i < numOps; i++) {
-            pool.enqueue(new RepairOperation("key-" + i, (long) i, null));
+            queue.enqueue(new RepairOperation("key-" + i, (long) i, null));
         }
 
         assertTrue(inProgress.await(5, TimeUnit.SECONDS),
@@ -79,15 +96,16 @@ class RepairWorkerPoolTest {
     // -------------------------------------------------------------------------
 
     @Test
-    void testPendingCountReflectsUniqueKeys() {
-        pool = new RepairWorkerPool(new WriteTracker(), op -> {});
+    void testPendingCountReflectsUniqueKeys() throws Exception {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 60_000L, op -> {});
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
-        pool.enqueue(new RepairOperation("key2", 2L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key2", 2L, null));
         assertEquals(2, pool.pendingCount());
 
         // Re-enqueuing key1 with a higher seqOffset compacts — count stays at 2
-        pool.enqueue(new RepairOperation("key1", 3L, null));
+        queue.enqueue(new RepairOperation("key1", 3L, null));
         assertEquals(2, pool.pendingCount());
     }
 
@@ -96,15 +114,16 @@ class RepairWorkerPoolTest {
         List<RepairOperation> executed = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch latch = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 50L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 50L, op -> {
             executed.add(op);
             latch.countDown();
         });
         pool.start();
 
         // Enqueue same key twice: second has higher seqOffset so it wins
-        pool.enqueue(new RepairOperation("key1", 1L, null));
-        pool.enqueue(new RepairOperation("key1", 2L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key1", 2L, null));
 
         assertTrue(latch.await(2, TimeUnit.SECONDS), "Exactly one execution should fire");
         Thread.sleep(150); // confirm no second execution arrives
@@ -118,7 +137,8 @@ class RepairWorkerPoolTest {
         CountDownLatch latch = new CountDownLatch(1);
         List<String> executions = Collections.synchronizedList(new ArrayList<>());
 
-        pool = new RepairWorkerPool(new WriteTracker(), 100L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 100L, op -> {
             executions.add(op.blobKey());
             latch.countDown();
         });
@@ -126,7 +146,7 @@ class RepairWorkerPoolTest {
 
         // Enqueue same key 10 times with ascending seqOffsets
         for (int i = 0; i < 10; i++) {
-            pool.enqueue(new RepairOperation("hot-key", (long) i, null));
+            queue.enqueue(new RepairOperation("hot-key", (long) i, null));
         }
         assertEquals(1, pool.pendingCount(), "All enqueues for same key should compact to 1");
 
@@ -145,15 +165,16 @@ class RepairWorkerPoolTest {
         List<RepairOperation> executed = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch latch = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 50L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 50L, op -> {
             executed.add(op);
             latch.countDown();
         });
         pool.start();
 
         // Higher seqOffset enqueued first, then lower — lower should be discarded
-        pool.enqueue(new RepairOperation("key1", 10L, null));
-        pool.enqueue(new RepairOperation("key1", 5L, null));
+        queue.enqueue(new RepairOperation("key1", 10L, null));
+        queue.enqueue(new RepairOperation("key1", 5L, null));
 
         assertTrue(latch.await(2, TimeUnit.SECONDS));
         Thread.sleep(150);
@@ -167,15 +188,16 @@ class RepairWorkerPoolTest {
         List<RepairOperation> executed = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch latch = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 50L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 50L, op -> {
             executed.add(op);
             latch.countDown();
         });
         pool.start();
 
         // Lower seqOffset enqueued first, then higher — higher should overwrite
-        pool.enqueue(new RepairOperation("key1", 5L, null));
-        pool.enqueue(new RepairOperation("key1", 10L, null));
+        queue.enqueue(new RepairOperation("key1", 5L, null));
+        queue.enqueue(new RepairOperation("key1", 10L, null));
 
         assertTrue(latch.await(2, TimeUnit.SECONDS));
         Thread.sleep(150);
@@ -189,14 +211,15 @@ class RepairWorkerPoolTest {
         List<RepairOperation> executed = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch latch = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 50L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 50L, op -> {
             executed.add(op);
             latch.countDown();
         });
         pool.start();
 
-        pool.enqueue(new RepairOperation("key1", 7L, null));
-        pool.enqueue(new RepairOperation("key1", 7L, null));
+        queue.enqueue(new RepairOperation("key1", 7L, null));
+        queue.enqueue(new RepairOperation("key1", 7L, null));
 
         assertTrue(latch.await(2, TimeUnit.SECONDS));
         Thread.sleep(150);
@@ -215,19 +238,20 @@ class RepairWorkerPoolTest {
         WriteTracker writeTracker = new WriteTracker();
         CountDownLatch executed = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(writeTracker, 50L, op -> executed.countDown());
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, writeTracker, 50L, op -> executed.countDown());
         pool.start();
 
-        // Mark write as in progress before the delay fires
+        // Mark write as in progress before the poll fires
         writeTracker.begin("key1");
-        pool.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
 
-        // Delay fires but write is still in progress → re-enqueued, not executed
+        // Poll fires but write is still in progress → deferred
         Thread.sleep(120);
         assertEquals(1, executed.getCount(), "Should not have executed while write is in progress");
-        assertEquals(1, pool.pendingCount(), "Should be re-enqueued while write is in progress");
+        assertEquals(1, pool.pendingCount(), "Should remain pending while write is in progress");
 
-        // Release write → next delay fires and executes
+        // Release write → next poll fires and executes
         writeTracker.end("key1");
         assertTrue(executed.await(2, TimeUnit.SECONDS), "Should execute after write completes");
     }
@@ -236,10 +260,11 @@ class RepairWorkerPoolTest {
     void testRepairExecutesImmediatelyWhenNoActiveWrite() throws Exception {
         CountDownLatch executed = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 50L, op -> executed.countDown());
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 50L, op -> executed.countDown());
         pool.start();
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
 
         assertTrue(executed.await(2, TimeUnit.SECONDS), "Should execute when no active write");
     }
@@ -252,13 +277,15 @@ class RepairWorkerPoolTest {
     void testPendingCountDropsToZeroAfterDispatch() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 50L, op -> latch.countDown());
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 50L, op -> latch.countDown());
         pool.start();
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
         assertEquals(1, pool.pendingCount());
 
         assertTrue(latch.await(2, TimeUnit.SECONDS));
+        Thread.sleep(100); // allow remove() to complete
         assertEquals(0, pool.pendingCount(), "Map should be empty after dispatch");
     }
 
@@ -271,7 +298,8 @@ class RepairWorkerPoolTest {
         CountDownLatch started = new CountDownLatch(1);
         CountDownLatch release = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 0L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 1L, op -> {
             started.countDown();
             try {
                 release.await(10, TimeUnit.SECONDS);
@@ -282,7 +310,7 @@ class RepairWorkerPoolTest {
         pool.start();
         assertTrue(pool.isRunning());
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
         assertTrue(started.await(5, TimeUnit.SECONDS));
 
         pool.shutdown();
@@ -294,10 +322,11 @@ class RepairWorkerPoolTest {
         CountDownLatch executed = new CountDownLatch(1);
 
         // Long delay — task should never fire because shutdown cancels it
-        pool = new RepairWorkerPool(new WriteTracker(), 5_000L, op -> executed.countDown());
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 5_000L, op -> executed.countDown());
         pool.start();
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
+        queue.enqueue(new RepairOperation("key1", 1L, null));
         assertEquals(1, pool.pendingCount());
 
         pool.shutdown();
@@ -307,15 +336,17 @@ class RepairWorkerPoolTest {
     }
 
     @Test
-    void testNullEnqueueIgnored() {
-        pool = new RepairWorkerPool(new WriteTracker(), op -> {});
-        pool.enqueue(null);
+    void testNullEnqueueIgnored() throws Exception {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 60_000L, op -> {});
+        queue.enqueue(null);
         assertEquals(0, pool.pendingCount());
     }
 
     @Test
-    void testDoubleStartThrows() {
-        pool = new RepairWorkerPool(new WriteTracker(), op -> {});
+    void testDoubleStartThrows() throws Exception {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 60_000L, op -> {});
         pool.start();
         assertThrows(IllegalStateException.class, () -> pool.start());
     }
@@ -329,14 +360,15 @@ class RepairWorkerPoolTest {
         List<RepairOperation> strategyReceived = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch latch = new CountDownLatch(1);
 
-        pool = new RepairWorkerPool(new WriteTracker(), 0L, op -> {
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 1L, op -> {
             strategyReceived.add(op);
             latch.countDown();
         });
         pool.start();
 
         RepairOperation op = new RepairOperation("test-key", 42L, null);
-        pool.enqueue(op);
+        queue.enqueue(op);
 
         assertTrue(latch.await(2, TimeUnit.SECONDS));
         assertEquals(1, strategyReceived.size());
@@ -346,12 +378,12 @@ class RepairWorkerPoolTest {
 
     @Test
     void testNullStrategyDoesNotThrow() throws Exception {
-        // Verify that a null strategy is handled gracefully
-        pool = new RepairWorkerPool(new WriteTracker(), 0L, null);
+        queue = createQueue();
+        pool = new RepairWorkerPool(queue, new WriteTracker(), 1L, null);
         pool.start();
 
-        pool.enqueue(new RepairOperation("key1", 1L, null));
-        Thread.sleep(200); // let dispatch fire
+        queue.enqueue(new RepairOperation("key1", 1L, null));
+        Thread.sleep(200); // let poll fire
         // Should not throw — just logs a warning
         assertEquals(0, pool.pendingCount());
     }

--- a/storage-node/src/test/java/com/github/koop/storagenode/RepairWorkerPoolTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/RepairWorkerPoolTest.java
@@ -19,19 +19,23 @@ class RepairWorkerPoolTest {
 
     private RepairWorkerPool pool;
     private RocksDbRepairQueue queue;
+    private RocksDbStorageStrategy strategy;
 
     @TempDir
     Path tempDir;
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws Exception {
         if (pool != null) {
             pool.shutdown();
+        }
+        if (strategy != null) {
+            strategy.close();
         }
     }
 
     private RocksDbRepairQueue createQueue() throws Exception {
-        RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(
+        strategy = new RocksDbStorageStrategy(
                 tempDir.resolve("db-" + System.nanoTime()).toAbsolutePath().toString());
         queue = new RocksDbRepairQueue(strategy);
         return queue;

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
@@ -38,6 +38,7 @@ class StorageNodeRepairTest {
     private HttpClient http;
     private int port;
     private Database db;
+    private RocksDbRepairQueue repairQueue;
     private MetadataClient metadataClient;
     private MemoryFetcher fetcher;
     private PubSubClient pubSubClient;
@@ -49,7 +50,9 @@ class StorageNodeRepairTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        db = new Database(new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString()));
+        RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString());
+        repairQueue = new RocksDbRepairQueue(strategy);
+        db = new Database(strategy);
         fetcher = new MemoryFetcher();
         metadataClient = new MetadataClient(fetcher);
         pubSub = new MemoryPubSub();
@@ -91,7 +94,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testNodeServesTrafficImmediatelyAfterStart() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
         port = server.port();
 
@@ -108,7 +111,7 @@ class StorageNodeRepairTest {
     @Test
     void testExistingFunctionalityPreservedWithRepair() throws Exception {
         // Full PUT -> commit -> GET cycle should still work with repair infrastructure present
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
         port = server.port();
 
@@ -147,7 +150,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testCommitMissEnqueuesRepairWhenBlobAbsent() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
 
         // Deliver a commit message with no prior PUT — blob is not on disk
@@ -160,7 +163,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testNoRepairEnqueuedWhenBlobAlreadyMaterialized() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
         port = server.port();
 
@@ -189,7 +192,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testGetOnMissingBlobReturns404WithoutEnqueueingRepair() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
         port = server.port();
 
@@ -219,7 +222,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testDeleteMessageDoesNotEnqueueRepair() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
 
         server.processSequencerMessage(6,
@@ -231,7 +234,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testCreateBucketMessageDoesNotEnqueueRepair() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
 
         server.processSequencerMessage(7,
@@ -247,7 +250,7 @@ class StorageNodeRepairTest {
 
     @Test
     void testNewerCommitMissOverridesOlderForSameKey() throws Exception {
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
 
         // Two commits for the same key — second has higher seqNumber
@@ -297,7 +300,7 @@ class StorageNodeRepairTest {
 
         try {
             // Start node under test
-            server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+            server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
             server.start();
             port = server.port();
 

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
@@ -85,7 +85,7 @@ class StorageNodeRepairTest {
     @AfterEach
     void tearDown() throws Exception {
         if (server != null) server.stop();
-        if (db != null) db.close();
+        //if (db != null) db.close();
         if (ackServer != null) ackServer.stop();
         if (metadataClient != null) metadataClient.close();
         if (pubSubClient != null) pubSubClient.close();

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
@@ -85,7 +85,7 @@ class StorageNodeRepairTest {
     @AfterEach
     void tearDown() throws Exception {
         if (server != null) server.stop();
-        //if (db != null) db.close();
+        if (db != null) db.close();
         if (ackServer != null) ackServer.stop();
         if (metadataClient != null) metadataClient.close();
         if (pubSubClient != null) pubSubClient.close();

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -53,7 +53,9 @@ class StorageNodeServerV2Test {
 
     @BeforeEach
     void setUp() throws Exception {
-        db = new Database(new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString()));
+        RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString());
+        RocksDbRepairQueue repairQueue = new RocksDbRepairQueue(strategy);
+        db = new Database(strategy);
         fetcher = new MemoryFetcher();
         metadataClient = new MetadataClient(fetcher);
         pubSub = new MemoryPubSub();
@@ -75,7 +77,7 @@ class StorageNodeServerV2Test {
             config.routes.post("/ack/{requestId}", ctx -> ctx.status(200));
         }).start(0);
 
-        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient);
+        server = new StorageNodeServerV2(0, "127.0.0.1", db, tempDir, metadataClient, pubSubClient, repairQueue);
         server.start();
         port = server.port();
 

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -93,7 +93,7 @@ class StorageNodeServerV2Test {
     @AfterEach
     void tearDown() throws Exception {
         server.stop();
-        db.close();
+        //db.close();
         ackServer.stop();
     }
 

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -93,7 +93,7 @@ class StorageNodeServerV2Test {
     @AfterEach
     void tearDown() throws Exception {
         server.stop();
-        //db.close();
+        db.close();
         ackServer.stop();
     }
 

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
@@ -48,7 +48,7 @@ public class StorageNodeV2Test {
 
     @AfterEach
     public void teardown() throws Exception {
-        db.close();
+        //db.close();
     }
 
     @Test

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
@@ -295,7 +295,10 @@ public class StorageNodeV2Test {
     @Test
     public void testRetrieveReturnEmptyForMissingBlobWithoutEnqueueingRepair() throws Exception {
         WriteTracker tracker = new WriteTracker();
-        RepairWorkerPool repairPool = new RepairWorkerPool(tracker, op -> {});
+        RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(
+                tempDir.resolve("repair-db").toAbsolutePath().toString());
+        RocksDbRepairQueue repairQueue = new RocksDbRepairQueue(strategy);
+        RepairWorkerPool repairPool = new RepairWorkerPool(repairQueue, tracker, op -> {});
         repairPool.start();
         storageNode = new StorageNodeV2(db, tempDir, tracker);
 

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeV2Test.java
@@ -48,7 +48,7 @@ public class StorageNodeV2Test {
 
     @AfterEach
     public void teardown() throws Exception {
-        //db.close();
+        db.close();
     }
 
     @Test
@@ -314,6 +314,7 @@ public class StorageNodeV2Test {
                 "retrieve() should not enqueue repair — only the commit path triggers repair");
 
         repairPool.shutdown();
+        strategy.close();
     }
 
     @Test

--- a/system-tests/src/test/java/koop/MultipartUploadIT.java
+++ b/system-tests/src/test/java/koop/MultipartUploadIT.java
@@ -16,6 +16,7 @@ import com.github.koop.queryprocessor.processor.MultipartUploadResult;
 import com.github.koop.queryprocessor.processor.StorageWorker;
 import com.github.koop.queryprocessor.processor.cache.MemoryCacheClient;
 import com.github.koop.queryprocessor.processor.cache.MultipartUploadSession;
+import com.github.koop.storagenode.RocksDbRepairQueue;
 import com.github.koop.storagenode.StorageNodeServerV2;
 import com.github.koop.storagenode.db.Database;
 import com.github.koop.storagenode.db.RocksDbStorageStrategy;
@@ -100,10 +101,12 @@ public class MultipartUploadIT {
             int port = freePort();
             Path dir = Files.createTempDirectory("mpu-storagenode-" + i + "-");
 
-            Database db = new Database(new RocksDbStorageStrategy(dir.resolve("db").toString()));
+            RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(dir.resolve("db").toString());
+            RocksDbRepairQueue repairQueue = new RocksDbRepairQueue(strategy);
+            Database db = new Database(strategy);
             StorageNodeServerV2 server =
                     new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"),
-                            sharedMetadataClient, sharedPubSubClient);
+                            sharedMetadataClient, sharedPubSubClient, repairQueue);
 
             servers.add(server);
             dataDirs.add(dir);

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -11,6 +11,7 @@ import com.github.koop.common.pubsub.MemoryPubSub;
 import com.github.koop.common.pubsub.PubSubClient;
 import com.github.koop.queryprocessor.processor.CommitCoordinator;
 import com.github.koop.queryprocessor.processor.StorageWorker;
+import com.github.koop.storagenode.RocksDbRepairQueue;
 import com.github.koop.storagenode.StorageNodeServerV2;
 import com.github.koop.storagenode.db.Database;
 import com.github.koop.storagenode.db.RocksDbStorageStrategy;
@@ -85,9 +86,11 @@ public class RealStorageNodesIT {
             log("Starting node " + i + " on port " + port);
 
             // Each node gets its own Database instance but shares the memory-backed control planes
-            Database db = new Database(new RocksDbStorageStrategy(dir.resolve("db").toString()));
+            RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(dir.resolve("db").toString());
+            RocksDbRepairQueue repairQueue = new RocksDbRepairQueue(strategy);
+            Database db = new Database(strategy);
             StorageNodeServerV2 server =
-                    new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"), sharedMetadataClient, sharedPubSubClient);
+                    new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"), sharedMetadataClient, sharedPubSubClient, repairQueue);
 
             servers.add(server);
             dataDirs.add(dir);

--- a/system-tests/src/test/java/koop/S3GatewayE2EIT.java
+++ b/system-tests/src/test/java/koop/S3GatewayE2EIT.java
@@ -15,6 +15,7 @@ import com.github.koop.queryprocessor.gateway.StorageServices.StorageWorkerServi
 import com.github.koop.queryprocessor.processor.CommitCoordinator;
 import com.github.koop.queryprocessor.processor.StorageWorker;
 import com.github.koop.queryprocessor.processor.cache.MemoryCacheClient;
+import com.github.koop.storagenode.RocksDbRepairQueue;
 import com.github.koop.storagenode.StorageNodeServerV2;
 import com.github.koop.storagenode.db.Database;
 import com.github.koop.storagenode.db.RocksDbStorageStrategy;
@@ -117,10 +118,12 @@ public class S3GatewayE2EIT {
             int port = freePort();
             Path dir = Files.createTempDirectory("e2e-storagenode-" + i + "-");
 
-            Database db = new Database(new RocksDbStorageStrategy(dir.resolve("db").toString()));
+            RocksDbStorageStrategy strategy = new RocksDbStorageStrategy(dir.resolve("db").toString());
+            RocksDbRepairQueue repairQueue = new RocksDbRepairQueue(strategy);
+            Database db = new Database(strategy);
             StorageNodeServerV2 server =
                     new StorageNodeServerV2(port, "127.0.0.1", db, dir.resolve("data"),
-                            sharedMetadataClient, sharedPubSubClient);
+                            sharedMetadataClient, sharedPubSubClient, repairQueue);
 
             servers.add(server);
             dataDirs.add(dir);


### PR DESCRIPTION
This pull request introduces a persistent, RocksDB-backed repair queue to the storage node, replacing the previous in-memory approach. The new design ensures repair operations survive restarts and are processed reliably, with deduplication and retry logic handled at the storage layer. The `RepairWorkerPool` is refactored to poll and dispatch repairs from this persistent queue, and all relevant components are updated to use the new system.

Key changes include:

**Persistent Repair Queue Implementation:**
- Added a new `RocksDbRepairQueue` class that persists repair operations in RocksDB, deduplicates by `blobKey`, and provides polling/removal APIs for the worker pool. It ensures only the latest repair per blob is retained and automatically cleans up corrupt or superseded entries.

**Integration with Repair Worker Pool:**
- Refactored `RepairWorkerPool` to poll and dispatch repairs from `RocksDbRepairQueue` instead of an in-memory map, handling deferred operations and retries robustly. The worker pool now tracks in-flight repairs and removes completed operations from the persistent queue. [[1]](diffhunk://#diff-1056a91feb6b3f9a5266c3faa371cba3df809a75088a6e6eafa1b66ff4b2ebccR3-R69) [[2]](diffhunk://#diff-1056a91feb6b3f9a5266c3faa371cba3df809a75088a6e6eafa1b66ff4b2ebccL118-R129)

**Repair Operation Serialization:**
- Added serialization and deserialization methods to `RepairOperation` to enable storing and retrieving repair tasks as byte arrays in RocksDB. [[1]](diffhunk://#diff-3b0f1d3536f69c2c5ff884e7261a34fe583784594b2dbae78b6fcf22a2549e4dR3-R4) [[2]](diffhunk://#diff-3b0f1d3536f69c2c5ff884e7261a34fe583784594b2dbae78b6fcf22a2549e4dR16-R42)

**Wiring and Usage in Server:**
- Updated `StorageNodeServerV2` to construct and use the new `RocksDbRepairQueue` and pass it to the `RepairWorkerPool`. All repair enqueues now go through the persistent queue. [[1]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968R49) [[2]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968L66-R73) [[3]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968R99-R104) [[4]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968L137-R140) [[5]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968L356-R359)

**RocksDB Storage Changes:**
- Modified `RocksDbStorageStrategy` to add a new column family for the repair queue and expose methods for manipulating repair entries. [[1]](diffhunk://#diff-5456e9023337f8b1b2f0f441d514aad6446dff8ea98f0b15cc61ecb6ddc635e1R20) [[2]](diffhunk://#diff-5456e9023337f8b1b2f0f441d514aad6446dff8ea98f0b15cc61ecb6ddc635e1L30-R32) [[3]](diffhunk://#diff-5456e9023337f8b1b2f0f441d514aad6446dff8ea98f0b15cc61ecb6ddc635e1R45)