### PR TITLE
fix metadata

### DIFF
--- a/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
+++ b/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
@@ -13,24 +13,23 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Stateless erasure coding utility using Reed-Solomon with configurable
- * {@code k}-of-{@code n}
- * shard layouts.
+ * {@code m}-of-{@code n} shard layouts, where {@code m} is the number of
+ * data shards and {@code k = n - m} parity shards are computed dynamically.
  *
  * Sharding:
  * {@link #shard(InputStream, long, int, int)} splits a data stream into
  * {@code n} shard streams.
- * The first {@code k} shards are data shards; the remaining {@code n - k}
+ * The first {@code m} shards are data shards; the remaining {@code k}
  * shards are parity shards.
  * Each returned {@link InputStream} begins with an 8-byte original-length
- * prefix so the receiver
- * can trim padding on reconstruction.
+ * prefix so the receiver can trim padding on reconstruction.
  *
  * Reconstruction:
  * {@link #reconstruct(InputStream[], boolean[], int, int)} accepts up to
  * {@code n} shard streams
  * ({@code false} entries for missing shards) and returns the original data
  * stream.
- * At least {@code k} shards must be present.
+ * At least {@code m} shards must be present.
  */
 public final class ErasureCoder {
 
@@ -190,20 +189,20 @@ public final class ErasureCoder {
     // Sharding
     // -------------------------------------------------------------------------
 
-    public static InputStream[] shard(InputStream data, long length, int k, int n) throws IOException {
+    public static InputStream[] shard(InputStream data, long length, int m, int n) throws IOException {
         if (data == null)
             throw new IllegalArgumentException("data is null");
         if (length < 0)
             throw new IllegalArgumentException("length < 0");
-        if (k == 0)
-            throw new IllegalArgumentException("k must be > 0");
+        if (m == 0)
+            throw new IllegalArgumentException("m must be > 0");
         if (n == 0)
             throw new IllegalArgumentException("n must be > 0");
-        if (k > n)
-            throw new IllegalArgumentException("k must be <= n");
+        if (m > n)
+            throw new IllegalArgumentException("m must be <= n");
 
-        int m = n - k;
-        long numStripes = (length + (long) k * SHARD_SIZE - 1) / ((long) k * SHARD_SIZE);
+        int k = n - m;
+        long numStripes = (length + (long) m * SHARD_SIZE - 1) / ((long) m * SHARD_SIZE);
         // +2 accounts for the length-prefix chunk and the EOF marker so both fit
         // in the queue even before the consumer starts reading (avoids close() timeout
         // on zero- or single-stripe inputs).
@@ -226,8 +225,8 @@ public final class ErasureCoder {
                 for (int i = 0; i < n; i++)
                     pos[i].write(lenBytes);
 
-                ReedSolomon rs = ReedSolomon.create(k, m);
-                byte[] stripeBuf = new byte[k * SHARD_SIZE];
+                ReedSolomon rs = ReedSolomon.create(m, k);
+                byte[] stripeBuf = new byte[m * SHARD_SIZE];
                 long remaining = length;
                 boolean[] dead = new boolean[n];
 
@@ -243,7 +242,7 @@ public final class ErasureCoder {
                     // Allocate fresh arrays per stripe so each array can be enqueued
                     // directly without an extra copy inside the pipe.
                     byte[][] shards = new byte[n][SHARD_SIZE];
-                    for (int i = 0; i < k; i++) {
+                    for (int i = 0; i < m; i++) {
                         System.arraycopy(stripeBuf, i * SHARD_SIZE, shards[i], 0, SHARD_SIZE);
                     }
                     rs.encodeParity(shards, 0, SHARD_SIZE);
@@ -282,7 +281,7 @@ public final class ErasureCoder {
     // Reconstruction
     // -------------------------------------------------------------------------
 
-    public static InputStream reconstruct(InputStream[] shards, boolean[] present, int k, int n) throws IOException {
+    public static InputStream reconstruct(InputStream[] shards, boolean[] present, int m, int n) throws IOException {
         if (shards == null || shards.length != n)
             throw new IllegalArgumentException("shards must have length " + n);
         if (present == null || present.length != n)
@@ -292,17 +291,17 @@ public final class ErasureCoder {
         for (boolean b : present)
             if (b)
                 count++;
-        if (count < k)
-            throw new IllegalArgumentException("need at least " + k + " shards, got " + count);
+        if (count < m)
+            throw new IllegalArgumentException("need at least " + m + " shards, got " + count);
 
-        int m = n - k;
+        int k = n - m;
         DataInputStream[] dis = new DataInputStream[n];
         for (int i = 0; i < n; i++) {
             if (present[i])
                 dis[i] = new DataInputStream(new BufferedInputStream(shards[i]));
         }
 
-        ThreadSafePipe pipe = new ThreadSafePipe(4 * k);
+        ThreadSafePipe pipe = new ThreadSafePipe(4 * m);
         InputStream pis = pipe.in;
         OutputStream pos = pipe.out;
 
@@ -323,7 +322,7 @@ public final class ErasureCoder {
                         dis[i].readLong();
                 }
 
-                ReedSolomon rs = ReedSolomon.create(k, m);
+                ReedSolomon rs = ReedSolomon.create(m, k);
                 byte[][] stripe = new byte[n][SHARD_SIZE];
                 long remaining = originalLength;
 
@@ -335,9 +334,9 @@ public final class ErasureCoder {
 
                     rs.decodeMissing(stripe, pres, 0, SHARD_SIZE);
 
-                    int toWrite = (int) Math.min((long) k * SHARD_SIZE, remaining);
+                    int toWrite = (int) Math.min((long) m * SHARD_SIZE, remaining);
                     int left = toWrite;
-                    for (int i = 0; i < k && left > 0; i++) {
+                    for (int i = 0; i < m && left > 0; i++) {
                         int nBytes = Math.min(SHARD_SIZE, left);
                         pos.write(stripe[i], 0, nBytes);
                         left -= nBytes;

--- a/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
+++ b/common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java
@@ -18,7 +18,7 @@ public class ErasureSetConfiguration {
     public static class ErasureSet {
         private int number;
         private int n;
-        private int k;
+        private int m;
         @JsonProperty("write_quorum")
         private int writeQuorum;
         private List<Machine> machines;
@@ -39,12 +39,17 @@ public class ErasureSetConfiguration {
             this.n = n;
         }
 
-        public int getK() {
-            return k;
+        public int getM() {
+            return m;
         }
 
-        public void setK(int k) {
-            this.k = k;
+        public void setM(int m) {
+            this.m = m;
+        }
+
+        /** Parity shard count, computed dynamically as {@code n - m}. */
+        public int getK() {
+            return n - m;
         }
 
         public int getWriteQuorum() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
     command:
       - |
         sleep 5
-        etcdctl --endpoints=http://etcd1:2379 put erasure_set_configurations '{"erasure_sets":[{"number":1,"n":6,"k":4,"write_quorum":5,"machines":[{"ip":"storage-node-1","port":8080},{"ip":"storage-node-2","port":8080},{"ip":"storage-node-3","port":8080},{"ip":"storage-node-4","port":8080},{"ip":"storage-node-5","port":8080},{"ip":"storage-node-6","port":8080}]},{"number":2,"n":6,"k":4,"write_quorum":5,"machines":[{"ip":"storage-node-1","port":8080},{"ip":"storage-node-2","port":8080},{"ip":"storage-node-3","port":8080},{"ip":"storage-node-4","port":8080},{"ip":"storage-node-5","port":8080},{"ip":"storage-node-6","port":8080}]}]}'
+        etcdctl --endpoints=http://etcd1:2379 put erasure_set_configurations '{"erasure_sets":[{"number":1,"n":6,"m":4,"write_quorum":5,"machines":[{"ip":"storage-node-1","port":8080},{"ip":"storage-node-2","port":8080},{"ip":"storage-node-3","port":8080},{"ip":"storage-node-4","port":8080},{"ip":"storage-node-5","port":8080},{"ip":"storage-node-6","port":8080}]},{"number":2,"n":6,"m":4,"write_quorum":5,"machines":[{"ip":"storage-node-1","port":8080},{"ip":"storage-node-2","port":8080},{"ip":"storage-node-3","port":8080},{"ip":"storage-node-4","port":8080},{"ip":"storage-node-5","port":8080},{"ip":"storage-node-6","port":8080}]}]}'
         etcdctl --endpoints=http://etcd1:2379 put partition_spread_configurations '{"partition_spread":[{"erasure_set":1,"partitions":[0,1,2]},{"erasure_set":2,"partitions":[3,4,5]}]}'
         echo "Etcd seeding complete"
 

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java
@@ -21,6 +21,7 @@ import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -31,9 +32,11 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
@@ -49,6 +52,9 @@ import org.apache.logging.log4j.Logger;
 public final class StorageWorker {
 
     private static final Logger logger = LogManager.getLogger(StorageWorker.class);
+
+    private static final int SHARD_UPLOAD_TIMEOUT_SECONDS = 30;
+    private static final int SHARD_FETCH_TIMEOUT_SECONDS = 30;
 
     private final ExecutorService executor;
     private final HttpClient httpClient;
@@ -66,6 +72,7 @@ public final class StorageWorker {
         this.executor = Executors.newVirtualThreadPerTaskExecutor();
         this.httpClient = HttpClient.newBuilder()
                 .executor(Executors.newVirtualThreadPerTaskExecutor())
+                .connectTimeout(Duration.ofSeconds(10))
                 .build();
         this.metadataClient = metadataClient;
         this.commitCoordinator = commitCoordinator;
@@ -117,11 +124,11 @@ public final class StorageWorker {
                 .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
 
         int n = es.getN();
-        int k = es.getK();
+        int m = es.getM();
         int writeQuorum = es.getWriteQuorum();
 
         // Phase 1 – stream erasure-coded shards to all storage nodes concurrently.
-        InputStream[] shardStreams = ErasureCoder.shard(data, length, k, n);
+        InputStream[] shardStreams = ErasureCoder.shard(data, length, m, n);
 
         List<Callable<Boolean>> tasks = new ArrayList<>();
         for (int i = 0; i < n; i++) {
@@ -137,6 +144,7 @@ public final class StorageWorker {
                             .uri(uri)
                             .PUT(HttpRequest.BodyPublishers.ofInputStream(() -> shardStreams[index]))
                             .header("Content-Type", "application/octet-stream")
+                            .timeout(Duration.ofSeconds(SHARD_UPLOAD_TIMEOUT_SECONDS))
                             .build();
                     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
                     if (response.statusCode() == 200) {
@@ -153,10 +161,11 @@ public final class StorageWorker {
 
         long uploaded;
         try {
-            uploaded = executor.invokeAll(tasks).stream().filter(f -> {
+            uploaded = executor.invokeAll(tasks, SHARD_UPLOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .stream().filter(f -> {
                 try {
                     return f.get();
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (InterruptedException | ExecutionException | CancellationException e) {
                     logger.warn("Shard upload task error: {}", e.getMessage());
                     return false;
                 }
@@ -206,7 +215,7 @@ public final class StorageWorker {
         var resolvedNodes = es.getMachines().stream()
                 .map(m -> new InetSocketAddress(m.getIp(), m.getPort())).toList();
 
-        int k = es.getK();
+        int m = es.getM();
         int n = es.getN();
 
         // Synchronous probe: fetch shard metadata to detect tombstones/type
@@ -237,7 +246,7 @@ public final class StorageWorker {
                     storageKey);
             executor.execute(() -> {
                 try (pos) {
-                    handleMultipartGet(representative.chunks(), k, pos);
+                    handleMultipartGet(representative.chunks(), m, pos);
                 } catch (Exception e) {
                     logger.error("Failed to stream multipart data for key {}", storageKey, e);
                 }
@@ -246,10 +255,10 @@ public final class StorageWorker {
             // BLOB — reconstruct from erasure-coded shards
             executor.execute(() -> {
                 try (pos) {
-                    if (maxVersionResponses.size() >= k) {
-                        reconstructFromResponses(maxVersionResponses, resolvedNodes, k, n, pos);
+                    if (maxVersionResponses.size() >= m) {
+                        reconstructFromResponses(maxVersionResponses, resolvedNodes, m, n, pos);
                     } else {
-                        reconstructFromOlderVersion(resolvedPartition, storageKey, resolvedNodes, k, n, pos,
+                        reconstructFromOlderVersion(resolvedPartition, storageKey, resolvedNodes, m, n, pos,
                                 maxVersion, maxVersionResponses.size(), responses);
                     }
                 } catch (Exception e) {
@@ -261,7 +270,7 @@ public final class StorageWorker {
         return pis;
     }
 
-    private void processGetConsensus(int partition, String storageKey, List<InetSocketAddress> nodes, int k, int n,
+    private void processGetConsensus(int partition, String storageKey, List<InetSocketAddress> nodes, int m, int n,
             OutputStream out) throws IOException {
         // Initial fetch: gets data + metadata in one pass without specifying a version
         List<ShardResponse> responses = fetchShards(partition, storageKey, nodes, OptionalLong.empty());
@@ -283,26 +292,26 @@ public final class StorageWorker {
         if (representative.type() == ShardType.MULTIPART) {
             logger.debug("Latest version {} for key {} is multipart. Streaming chunks sequentially.", maxVersion,
                     storageKey);
-            handleMultipartGet(representative.chunks(), k, out);
+            handleMultipartGet(representative.chunks(), m, out);
             return;
         }
 
         // Type is BLOB
-        if (maxVersionResponses.size() >= k) {
-            reconstructFromResponses(maxVersionResponses, nodes, k, n, out);
+        if (maxVersionResponses.size() >= m) {
+            reconstructFromResponses(maxVersionResponses, nodes, m, n, out);
             return;
         }
 
-        reconstructFromOlderVersion(partition, storageKey, nodes, k, n, out, maxVersion, maxVersionResponses.size(),
+        reconstructFromOlderVersion(partition, storageKey, nodes, m, n, out, maxVersion, maxVersionResponses.size(),
                 responses);
     }
 
-    private void reconstructFromOlderVersion(int partition, String storageKey, List<InetSocketAddress> nodes, int k,
+    private void reconstructFromOlderVersion(int partition, String storageKey, List<InetSocketAddress> nodes, int m,
             int n,
             OutputStream out, long maxVersion, int maxVersionShardCount, List<ShardResponse> responses)
             throws IOException {
         logger.warn("Latest version {} for key {} has insufficient shards ({}/{}). Searching older versions.",
-                maxVersion, storageKey, maxVersionShardCount, k);
+                maxVersion, storageKey, maxVersionShardCount, m);
 
         List<Long> availableVersions = responses.stream()
                 .map(ShardResponse::version)
@@ -312,28 +321,28 @@ public final class StorageWorker {
 
         if (availableVersions.size() < 2) {
             throw new IOException("Only one version available for key " + storageKey
-                    + " and it has insufficient shards (" + maxVersionShardCount + "/" + k + ")");
+                    + " and it has insufficient shards (" + maxVersionShardCount + "/" + m + ")");
         }
 
         long oldVersion = availableVersions.get(1); // second-highest version
         List<ShardResponse> oldResponses = fetchShards(partition, storageKey, nodes, OptionalLong.of(oldVersion));
         List<ShardResponse> validOldResponses = oldResponses.stream().filter(r -> r.version() == oldVersion).toList();
-        if (validOldResponses.size() >= k) {
+        if (validOldResponses.size() >= m) {
             logger.debug("Found sufficient shards for version {} ({}/{}). Reconstructing.", oldVersion,
-                    validOldResponses.size(), k);
-            reconstructFromResponses(validOldResponses, nodes, k, n, out);
+                    validOldResponses.size(), m);
+            reconstructFromResponses(validOldResponses, nodes, m, n, out);
             return;
         }
 
         throw new IOException("Could not find any version with sufficient shards for key " + storageKey);
     }
 
-    private void handleMultipartGet(List<String> chunks, int k, OutputStream out) throws IOException {
+    private void handleMultipartGet(List<String> chunks, int m, OutputStream out) throws IOException {
         for (String chunkId : chunks) {
             var partition = getRouting().getPartition(chunkId)
                     .orElseThrow(() -> new IOException("No partition for chunk " + chunkId));
             List<InetSocketAddress> nodes = getNodesForPartition(partition);
-            processGetConsensus(partition, chunkId, nodes, k, nodes.size(), out);
+            processGetConsensus(partition, chunkId, nodes, m, nodes.size(), out);
         }
     }
 
@@ -351,7 +360,8 @@ public final class StorageWorker {
                     uriStr += "?version=" + targetVersion.getAsLong();
                 }
 
-                HttpRequest request = HttpRequest.newBuilder().uri(URI.create(uriStr)).GET().build();
+                HttpRequest request = HttpRequest.newBuilder().uri(URI.create(uriStr)).GET()
+                        .timeout(Duration.ofSeconds(SHARD_FETCH_TIMEOUT_SECONDS)).build();
                 HttpResponse<InputStream> response = httpClient.send(request,
                         HttpResponse.BodyHandlers.ofInputStream());
 
@@ -381,7 +391,7 @@ public final class StorageWorker {
         }
 
         try {
-            return executor.invokeAll(tasks).stream()
+            return executor.invokeAll(tasks, SHARD_FETCH_TIMEOUT_SECONDS, TimeUnit.SECONDS).stream()
                     .map(future -> {
                         try {
                             return future.get();
@@ -397,7 +407,7 @@ public final class StorageWorker {
         }
     }
 
-    private void reconstructFromResponses(List<ShardResponse> payloadResponses, List<InetSocketAddress> nodes, int k,
+    private void reconstructFromResponses(List<ShardResponse> payloadResponses, List<InetSocketAddress> nodes, int m,
             int n, OutputStream out) throws IOException {
         InputStream[] ins = new InputStream[n];
         boolean[] present = new boolean[n];
@@ -409,7 +419,7 @@ public final class StorageWorker {
             }
         }
 
-        try (InputStream reconstructed = ErasureCoder.reconstruct(ins, present, k, n)) {
+        try (InputStream reconstructed = ErasureCoder.reconstruct(ins, present, m, n)) {
             byte[] buf = new byte[64 * 1024];
             int bytesRead;
             while ((bytesRead = reconstructed.read(buf)) != -1) {
@@ -442,7 +452,7 @@ public final class StorageWorker {
 
     /**
      * Publishes a delete command via pub/sub and waits for {@code k + 1} SNs
-     * (the delete quorum) to acknowledge the tombstone.
+     * (where k = parity shards = n - m) to acknowledge the tombstone.
      */
     public boolean delete(UUID requestID, String bucket, String key) {
         if (requestID == null)
@@ -719,8 +729,9 @@ public final class StorageWorker {
             return false;
         }
 
+        int multipartQuorum = erasureSetOpt.get().getK() + 1;
         return commitCoordinator.beginMultipartCommit(requestId, partition.getAsInt(), bucket, key, chunks,
-                erasureSetOpt.get().getWriteQuorum());
+                multipartQuorum);
     }
 
     public void shutdown() {

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/MultipartUploadManagerTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/MultipartUploadManagerTest.java
@@ -348,6 +348,50 @@ class MultipartUploadManagerTest {
         }
 
     @Test
+    void uploadPart_storageWorkerTimeout_returnsFailure() throws Exception {
+        when(storageWorker.put(any(UUID.class), anyString(), anyString(), anyLong(), any(InputStream.class)))
+                .thenThrow(new java.io.IOException("Connection timed out"));
+
+        String uploadId = manager.initiateMultipartUpload("bucket", "file");
+        byte[] payload = "data".getBytes(StandardCharsets.UTF_8);
+
+        MultipartUploadResult result = manager.uploadPart(
+                "bucket", "file", uploadId, 1,
+                new ByteArrayInputStream(payload), payload.length);
+
+        assertEquals(MultipartUploadResult.Status.STORAGE_FAILURE, result.status());
+        // Part reservation should be cleaned up after failure
+        assertTrue(cache.setMembers(MultipartUploadSession.partsKey(uploadId)).isEmpty()
+                || !cache.setMembers(MultipartUploadSession.partsKey(uploadId)).contains("1"));
+    }
+
+    @Test
+    void complete_commitTimeout_canRetry() throws Exception {
+        when(storageWorker.put(any(UUID.class), anyString(), anyString(), anyLong(), any(InputStream.class)))
+                .thenReturn(true);
+
+        String uploadId = manager.initiateMultipartUpload("bucket", "final-key");
+        byte[] p1 = "a".getBytes(StandardCharsets.UTF_8);
+        manager.uploadPart("bucket", "final-key", uploadId, 1, new ByteArrayInputStream(p1), p1.length);
+
+        reset(storageWorker);
+        // First call: simulate timeout (returns false), second call: succeeds
+        when(storageWorker.beginMultipartCommit(eq("bucket"), eq("final-key"), eq(uploadId), eq(List.of(
+                "bucket/" + MultipartUploadSession.partStorageKey("bucket", "final-key", uploadId, 1)))))
+                .thenReturn(false, true);
+
+        List<StorageService.CompletedPart> parts = List.of(new StorageService.CompletedPart(1));
+
+        MultipartUploadResult first = manager.completeMultipartUpload("bucket", "final-key", uploadId, parts);
+        assertEquals(MultipartUploadResult.Status.STORAGE_FAILURE, first.status(),
+                "should fail when multipart commit times out");
+
+        MultipartUploadResult second = manager.completeMultipartUpload("bucket", "final-key", uploadId, parts);
+        assertEquals(MultipartUploadResult.Status.SUCCESS, second.status(),
+                "should succeed on retry after timeout");
+    }
+
+    @Test
     void concurrent_twoPartsUploadedSimultaneously() throws Exception {
         when(storageWorker.put(any(UUID.class), anyString(), anyString(), anyLong(), any(InputStream.class)))
                 .thenReturn(true);

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/processor/StorageWorkerApiTest.java
@@ -308,7 +308,7 @@ public class StorageWorkerApiTest {
             boolean ok = quorumWorker.put(UUID.randomUUID(), "b", "quorumFail",
                     data.length, new ByteArrayInputStream(data));
             assertFalse(ok,
-                    "put should fail when only 6/9 nodes ACK the commit (writeQuorum=k+1=7)");
+                    "put should fail when only 6/9 nodes ACK the commit (writeQuorum=m+1=7)");
         } finally {
             quorumWorker.shutdown();
             for (AckingFakeStorageNodeServer n : quorumNodes) n.close();
@@ -499,9 +499,9 @@ public class StorageWorkerApiTest {
         bus.start();
         List<AckingFakeStorageNodeServer> bucketNodes = new ArrayList<>();
         for (int i = 0; i < 9; i++) bucketNodes.add(new AckingFakeStorageNodeServer(bus));
-        bucketNodes.get(0).setEnabled(false);
-        bucketNodes.get(1).setEnabled(false);
-        bucketNodes.get(2).setEnabled(false);
+        // k = n - m = 9 - 6 = 3 parity shards; deleteQuorum = k + 1 = 4
+        // Disable 6 nodes so only 3 ACK (below quorum of 4)
+        for (int i = 0; i < 6; i++) bucketNodes.get(i).setEnabled(false);
         List<InetSocketAddress> set = bucketNodes.stream().map(AckingFakeStorageNodeServer::address).toList();
 
         MetadataClient client = createConfiguredClient(set);
@@ -509,7 +509,7 @@ public class StorageWorkerApiTest {
         StorageWorker w = new StorageWorker(client, fastCoordinator);
         try {
             assertFalse(w.createBucket(UUID.randomUUID(), "no-quorum-bucket"),
-                    "createBucket should fail when only 6/9 nodes ACK");
+                    "createBucket should fail when only 3/9 nodes ACK (deleteQuorum=k+1=4)");
         } finally {
             w.shutdown();
             for (AckingFakeStorageNodeServer n : bucketNodes) n.close();
@@ -778,6 +778,101 @@ public class StorageWorkerApiTest {
     }
 
     // -------------------------------------------------------------------------
+    // Timeout and unresponsive node tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void put_failsWhenCommitTimesOut() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+
+        List<AckingFakeStorageNodeServer> timeoutNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) timeoutNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = timeoutNodes.stream()
+                .map(AckingFakeStorageNodeServer::address).toList();
+
+        // Disable all nodes so no ACKs arrive — commit should time out
+        for (AckingFakeStorageNodeServer n : timeoutNodes) n.setEnabled(false);
+        // Keep upload endpoints open so Phase 1 succeeds
+        for (AckingFakeStorageNodeServer n : timeoutNodes) n.setUploadEnabled(true);
+
+        MetadataClient client = createConfiguredClient(set);
+        CommitCoordinator fastCoordinator = new CommitCoordinator(bus, 0, /*timeoutSeconds=*/ 2);
+        StorageWorker w = new StorageWorker(client, fastCoordinator);
+
+        try {
+            byte[] data = randomBytes(1024);
+            long start = System.currentTimeMillis();
+            boolean ok = w.put(UUID.randomUUID(), "b", "timeoutTest",
+                    data.length, new ByteArrayInputStream(data));
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertFalse(ok, "put should fail when commit times out with no ACKs");
+            assertTrue(elapsed < 10_000,
+                    "should fail within reasonable time, not hang indefinitely (took " + elapsed + "ms)");
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : timeoutNodes) n.close();
+        }
+    }
+
+    @Test
+    void delete_failsWhenBelowQuorum() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+
+        List<AckingFakeStorageNodeServer> deleteNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) deleteNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = deleteNodes.stream()
+                .map(AckingFakeStorageNodeServer::address).toList();
+
+        // k = n - m = 3 parity; deleteQuorum = k + 1 = 4
+        // Disable 6 nodes → only 3 ACK → below quorum
+        for (int i = 0; i < 6; i++) deleteNodes.get(i).setEnabled(false);
+
+        MetadataClient client = createConfiguredClient(set);
+        CommitCoordinator fastCoordinator = new CommitCoordinator(bus, 0, /*timeoutSeconds=*/ 2);
+        StorageWorker w = new StorageWorker(client, fastCoordinator);
+
+        try {
+            assertFalse(w.delete(UUID.randomUUID(), "b", "deleteTimeout"),
+                    "delete should fail when only 3/9 nodes ACK (deleteQuorum=k+1=4)");
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : deleteNodes) n.close();
+        }
+    }
+
+    @Test
+    void put_phase1FailsWhenAllNodesUnreachable() throws Exception {
+        PubSubClient bus = new PubSubClient(new MemoryPubSub());
+        bus.start();
+
+        List<AckingFakeStorageNodeServer> unreachableNodes = new ArrayList<>();
+        for (int i = 0; i < 9; i++) unreachableNodes.add(new AckingFakeStorageNodeServer(bus));
+        List<InetSocketAddress> set = unreachableNodes.stream()
+                .map(AckingFakeStorageNodeServer::address).toList();
+
+        // Disable upload on all nodes so Phase 1 gets 0 shards uploaded
+        for (AckingFakeStorageNodeServer n : unreachableNodes) n.setUploadEnabled(false);
+
+        MetadataClient client = createConfiguredClient(set);
+        CommitCoordinator coordinator = new CommitCoordinator(bus, 0, /*timeoutSeconds=*/ 2);
+        StorageWorker w = new StorageWorker(client, coordinator);
+
+        try {
+            byte[] data = randomBytes(1024);
+            boolean ok = w.put(UUID.randomUUID(), "b", "phase1Fail",
+                    data.length, new ByteArrayInputStream(data));
+            assertFalse(ok,
+                    "put should fail in Phase 1 when no nodes accept shard uploads");
+        } finally {
+            w.shutdown();
+            for (AckingFakeStorageNodeServer n : unreachableNodes) n.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -826,7 +921,7 @@ public class StorageWorkerApiTest {
         ErasureSet es = new ErasureSet();
         es.setNumber(number);
         es.setN(9);
-        es.setK(6);
+        es.setM(6);
         es.setWriteQuorum(7);
         es.setMachines(addresses.stream().map(addr -> {
             Machine m = new Machine();

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -440,7 +440,7 @@ public class StorageNodeServerV2 {
         ErasureSetConfiguration.ErasureSet es = esOpt.get();
         List<ErasureSetConfiguration.Machine> machines = es.getMachines();
         int n = es.getN();
-        int k = es.getK();
+        int m = es.getM();
 
         // 3. Determine this node's shard index (cached from last metadata update)
         int myIndex = this.myShardIndex;
@@ -479,13 +479,13 @@ public class StorageNodeServerV2 {
                 }
             }
 
-            if (fetched < k) {
-                logger.error("Repair failed: only {}/{} shards fetched for key={}", fetched, k, blobKey);
+            if (fetched < m) {
+                logger.error("Repair failed: only {}/{} shards fetched for key={}", fetched, m, blobKey);
                 return;
             }
 
             // 5. Reconstruct via erasure coding
-            try (InputStream reconstructed = ErasureCoder.reconstruct(shardStreams, present, k, n)) {
+            try (InputStream reconstructed = ErasureCoder.reconstruct(shardStreams, present, m, n)) {
                 // The reconstructed stream is the original data. We need to re-shard it
                 // to extract just our shard.
                 byte[] fullData = reconstructed.readAllBytes();
@@ -493,7 +493,7 @@ public class StorageNodeServerV2 {
                 // Re-shard to get this node's shard
                 InputStream[] resharded = ErasureCoder.shard(
                         new java.io.ByteArrayInputStream(fullData),
-                        fullData.length, k, n);
+                        fullData.length, m, n);
 
                 // Extract our shard
                 byte[] ourShard = resharded[myIndex].readAllBytes();

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeRepairTest.java
@@ -304,7 +304,7 @@ class StorageNodeRepairTest {
             // Provide populated metadata once the server port has been determined
             var es = new ErasureSetConfiguration.ErasureSet();
             es.setNumber(1);
-            es.setK(k);
+            es.setM(k);
             es.setN(n);
             var m0 = new ErasureSetConfiguration.Machine(); m0.setIp("127.0.0.1"); m0.setPort(port);
             var m1 = new ErasureSetConfiguration.Machine(); m1.setIp("127.0.0.1"); m1.setPort(peer1.port());

--- a/system-tests/src/test/java/koop/MultipartUploadIT.java
+++ b/system-tests/src/test/java/koop/MultipartUploadIT.java
@@ -118,7 +118,7 @@ public class MultipartUploadIT {
         ErasureSet es = new ErasureSet();
         es.setNumber(1);
         es.setN(9);
-        es.setK(6);
+        es.setM(6);
         es.setWriteQuorum(7);
         List<Machine> machines = new ArrayList<>();
         for (InetSocketAddress addr : addrs) {

--- a/system-tests/src/test/java/koop/MultipartUploadIT.java
+++ b/system-tests/src/test/java/koop/MultipartUploadIT.java
@@ -845,9 +845,11 @@ public class MultipartUploadIT {
                     "Part " + (i + 1) + " should succeed with healthy cluster");
         }
 
-        // Kill 4 nodes (more than erasure tolerance) — simulates "dies right here"
-        log("Killing 4 nodes mid-upload...");
-        stopNodes(0, 1, 2, 3);
+        // Kill 6 nodes (more than erasure tolerance) — simulates "dies right here"
+        // With k = n - m = 3 parity shards, multipart commit quorum = k + 1 = 4,
+        // so we need fewer than 4 alive nodes to block the commit.
+        log("Killing 6 nodes mid-upload...");
+        stopNodes(0, 1, 2, 3, 4, 5);
 
         // Attempt to upload part 3 — should fail due to insufficient nodes
         MultipartUploadResult r3 = multipartManager.uploadPart(
@@ -855,10 +857,10 @@ public class MultipartUploadIT {
                 new ByteArrayInputStream(partData[2]), partData[2].length);
         log("Part 3 after node failure: " + r3.status() + " - " + r3.message());
         assertFalse(r3.isSuccess(),
-                "Part upload should fail when nodes exceed erasure tolerance (4 of 9 down)");
+                "Part upload should fail when nodes exceed erasure tolerance (6 of 9 down)");
 
         // Completing with only the pre-failure parts should also fail since
-        // the cluster is degraded beyond tolerance
+        // the cluster is degraded beyond tolerance (3 alive < k+1=4 quorum)
         List<StorageService.CompletedPart> parts = List.of(
                 new StorageService.CompletedPart(1),
                 new StorageService.CompletedPart(2));

--- a/system-tests/src/test/java/koop/RealStorageNodesIT.java
+++ b/system-tests/src/test/java/koop/RealStorageNodesIT.java
@@ -107,7 +107,7 @@ public class RealStorageNodesIT {
         ErasureSet es = new ErasureSet();
         es.setNumber(1);
         es.setN(9);
-        es.setK(6);
+        es.setM(6);
         es.setWriteQuorum(7);
 
         List<Machine> machines = new ArrayList<>();

--- a/system-tests/src/test/java/koop/S3GatewayE2EIT.java
+++ b/system-tests/src/test/java/koop/S3GatewayE2EIT.java
@@ -135,7 +135,7 @@ public class S3GatewayE2EIT {
         ErasureSet es = new ErasureSet();
         es.setNumber(1);
         es.setN(9);
-        es.setK(6);
+        es.setM(6);
         es.setWriteQuorum(7);
         List<Machine> machines = new ArrayList<>();
         for (InetSocketAddress addr : addrs) {


### PR DESCRIPTION
This pull request refactors the erasure coding configuration and usage throughout the codebase to clarify the distinction between data shards (`m`) and parity shards (`k`), replacing the previous ambiguous use of `k` for both. The changes update method signatures, configuration objects, and documentation to consistently use `m` for data shards and compute `k` as `n - m`. Additionally, the pull request improves the robustness of shard upload/fetch operations by introducing timeouts and better error handling.

Key changes include:

### Erasure Coding Parameter Refactor

* Updated the `ErasureCoder` API and documentation to use `m` (data shards) and `k = n - m` (parity shards) instead of the previous `k`-of-`n` terminology, ensuring clarity and consistency across all methods and comments. (`common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java`) [[1]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL16-R32) [[2]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL193-R205) [[3]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL229-R229) [[4]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL246-R245) [[5]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL285-R284) [[6]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL295-R304) [[7]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL326-R325) [[8]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL338-R339)

* Refactored the `ErasureSet` class in `ErasureSetConfiguration` to use `m` for data shards, added getter/setter for `m`, and made `k` a computed property (`n - m`). (`common-lib/src/main/java/com/github/koop/common/metadata/ErasureSetConfiguration.java`) [[1]](diffhunk://#diff-b169db2678793dbea838b444a844e66d51d1be351916f689b9b9a73ed01b1c8fL21-R21) [[2]](diffhunk://#diff-b169db2678793dbea838b444a844e66d51d1be351916f689b9b9a73ed01b1c8fL42-R52)

* Updated the etcd seed data in `docker-compose.yml` to use the new `m` field instead of `k` for erasure set configurations. (`docker-compose.yml`)

### Query Processor Adaptation

* Modified `StorageWorker` and related logic to use `m` (data shards) instead of `k`, updating method signatures and erasure coding calls accordingly. (`query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java`) [[1]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL120-R131) [[2]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL209-R218) [[3]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL240-R249) [[4]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL249-R261) [[5]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL264-R273) [[6]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL286-R314)

### Robustness Improvements

* Added per-shard upload and fetch timeouts (30 seconds) and improved error handling for shard operations in `StorageWorker`, including handling `CancellationException` and setting HTTP request timeouts. (`query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java`) [[1]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dR56-R58) [[2]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dR75) [[3]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dR147) [[4]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dL156-R168)

### Dependency and Import Updates

* Added necessary imports for new concurrency and timeout handling features in `StorageWorker`. (`query-processor/src/main/java/com/github/koop/queryprocessor/processor/StorageWorker.java`) [[1]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dR24) [[2]](diffhunk://#diff-eb5991129028e60800d3c7ddd4a604801c402c1b95494fd4a49a94e0a9f9aa7dR35-R39)