### PR TITLE
watermark

### DIFF
--- a/storage-node/src/main/java/com/github/koop/storagenode/ActiveSequenceTracker.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/ActiveSequenceTracker.java
@@ -1,0 +1,101 @@
+package com.github.koop.storagenode;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracks per-partition state needed by the garbage-collection gossip protocol:
+ * <ul>
+ *   <li>The highest sequence number this node has processed for each partition
+ *       (the node is "currently up to" this value).</li>
+ *   <li>The sequence numbers of GET requests currently being served — these
+ *       sequence numbers cannot be reaped until the GETs complete.</li>
+ * </ul>
+ *
+ * <p>The lowest sequence number still in use on this node, for a given
+ * partition, is defined as
+ * {@code min(highWatermark[p], minActiveGetSeq[p])}. A partition for which
+ * neither value is known is omitted from the snapshot; the gossip layer
+ * treats absence as "no watermark, do not garbage collect anything here".
+ *
+ * <p>Active GETs are tracked with reference counts so that two concurrent
+ * GETs serving the same sequence number cannot accidentally unpin the
+ * version when the first one finishes.
+ */
+public class ActiveSequenceTracker {
+
+    private final Map<Integer, Long> highWatermark = new ConcurrentHashMap<>();
+    private final Map<Integer, ConcurrentSkipListMap<Long, AtomicInteger>> activeGets = new ConcurrentHashMap<>();
+
+    /**
+     * Record that this node has processed sequence number {@code seqNum}
+     * for {@code partition}. Monotonically advances the high-water mark.
+     */
+    public void recordProcessedSeq(int partition, long seqNum) {
+        highWatermark.merge(partition, seqNum, Math::max);
+    }
+
+    /** Mark a GET on {@code partition} that is serving sequence {@code seqNum}. */
+    public void beginGet(int partition, long seqNum) {
+        activeGets.computeIfAbsent(partition, p -> new ConcurrentSkipListMap<>())
+                  .computeIfAbsent(seqNum, s -> new AtomicInteger())
+                  .incrementAndGet();
+    }
+
+    /**
+     * Release a GET previously registered with {@link #beginGet(int, long)}.
+     * The entry is removed once the in-flight count for that sequence drops
+     * to zero — concurrent GETs on the same sequence are tracked by count.
+     */
+    public void endGet(int partition, long seqNum) {
+        ConcurrentSkipListMap<Long, AtomicInteger> map = activeGets.get(partition);
+        if (map == null) {
+            return;
+        }
+        map.computeIfPresent(seqNum, (k, count) -> count.decrementAndGet() <= 0 ? null : count);
+    }
+
+    /**
+     * Returns this node's lowest sequence number still in use for each
+     * partition it knows about. Partitions absent from the result are
+     * partitions the node has no information about, and the gossip layer
+     * deliberately omits them from the broadcast.
+     */
+    public Map<Integer, Long> snapshotLowestInUse() {
+        Map<Integer, Long> result = new HashMap<>();
+        Set<Integer> partitions = new java.util.HashSet<>(highWatermark.keySet());
+        partitions.addAll(activeGets.keySet());
+        for (Integer partition : partitions) {
+            Long hw = highWatermark.get(partition);
+            ConcurrentSkipListMap<Long, AtomicInteger> map = activeGets.get(partition);
+            Long lowestGet = null;
+            if (map != null) {
+                var entry = map.firstEntry();
+                if (entry != null) {
+                    lowestGet = entry.getKey();
+                }
+            }
+            long value;
+            if (hw == null && lowestGet == null) {
+                continue;
+            } else if (hw == null) {
+                value = lowestGet;
+            } else if (lowestGet == null) {
+                value = hw;
+            } else {
+                value = Math.min(hw, lowestGet);
+            }
+            result.put(partition, value);
+        }
+        return result;
+    }
+
+    /** Test helper: current high-water mark for {@code partition}, or {@code -1} if none. */
+    long highWatermark(int partition) {
+        return highWatermark.getOrDefault(partition, -1L);
+    }
+}

--- a/storage-node/src/main/java/com/github/koop/storagenode/GarbageCollectionWorker.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/GarbageCollectionWorker.java
@@ -1,0 +1,180 @@
+package com.github.koop.storagenode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.github.koop.storagenode.db.Database;
+import com.github.koop.storagenode.db.FileVersion;
+import com.github.koop.storagenode.db.Metadata;
+import com.github.koop.storagenode.db.MultipartFileVersion;
+import com.github.koop.storagenode.db.RegularFileVersion;
+import com.github.koop.storagenode.db.TombstoneFileVersion;
+
+/**
+ * Background worker that physically deletes shard files (and multipart chunks)
+ * whose versions have fallen below the gossip-derived safe-deletion watermark,
+ * and compacts the corresponding entries out of the metadata table.
+ *
+ * <p>Modeled after {@link RepairWorkerPool}: a single-threaded scheduled
+ * poller wakes periodically, walks every metadata row, and consults the
+ * {@link GossipService} for the per-partition watermark. For each row it
+ * removes versions whose sequence number is strictly less than the partition
+ * watermark via {@link Database#compactMetadata(String, long)} and then
+ * unlinks the on-disk files referenced by the removed versions.
+ */
+public class GarbageCollectionWorker {
+
+    private static final Logger logger = LogManager.getLogger(GarbageCollectionWorker.class);
+
+    static final long DEFAULT_GC_INTERVAL_MS = 5_000;
+
+    private final Database db;
+    private final StorageNodeV2 storageNode;
+    private final GossipService gossipService;
+    private final WriteTracker writeTracker;
+    private final long intervalMs;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("gc-worker").factory());
+    private volatile boolean running = false;
+
+    public GarbageCollectionWorker(Database db, StorageNodeV2 storageNode,
+                                   GossipService gossipService, WriteTracker writeTracker) {
+        this(db, storageNode, gossipService, writeTracker, DEFAULT_GC_INTERVAL_MS);
+    }
+
+    GarbageCollectionWorker(Database db, StorageNodeV2 storageNode,
+                            GossipService gossipService, WriteTracker writeTracker,
+                            long intervalMs) {
+        this.db = db;
+        this.storageNode = storageNode;
+        this.gossipService = gossipService;
+        this.writeTracker = writeTracker;
+        this.intervalMs = intervalMs;
+    }
+
+    public void start() {
+        if (running) {
+            throw new IllegalStateException("GarbageCollectionWorker already running");
+        }
+        running = true;
+        long period = Math.max(intervalMs, 1);
+        scheduler.scheduleWithFixedDelay(this::runOnce, period, period, TimeUnit.MILLISECONDS);
+        logger.info("GarbageCollectionWorker started, interval={}ms", intervalMs);
+    }
+
+    public void shutdown() {
+        running = false;
+        scheduler.shutdownNow();
+        try {
+            if (!scheduler.awaitTermination(10, TimeUnit.SECONDS)) {
+                logger.warn("GarbageCollectionWorker did not shut down within 10s");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Runs a single GC pass: scan every metadata row, drop versions that fall
+     * strictly below the gossip safe watermark for their partition, then unlink
+     * the physical blob/chunk files that those versions referenced.
+     *
+     * <p>Returns the number of physical files deleted in this pass. Exposed for
+     * tests and for explicit on-demand invocation.
+     */
+    public int runOnce() {
+        int filesDeleted = 0;
+        try {
+            List<Metadata> rows = new ArrayList<>();
+            try (Stream<Metadata> stream = db.streamAllMetadata()) {
+                stream.forEach(rows::add);
+            }
+            for (Metadata metadata : rows) {
+                filesDeleted += compactSingleKey(metadata);
+            }
+        } catch (Exception e) {
+            logger.error("GC pass failed", e);
+        }
+        return filesDeleted;
+    }
+
+    private int compactSingleKey(Metadata metadata) {
+        // Defer compaction while a write is in flight for this key — a
+        // concurrent putItem could be about to materialize a version, and we
+        // don't want to race the writer through the same metadata row.
+        if (writeTracker.isActive(metadata.key())) {
+            logger.debug("Skipping GC for key={}: write in progress", metadata.key());
+            return 0;
+        }
+
+        OptionalLong watermarkOpt = gossipService.safeWatermark(metadata.partition());
+        if (watermarkOpt.isEmpty()) {
+            return 0;
+        }
+        long watermark = watermarkOpt.getAsLong();
+
+        List<FileVersion> removed;
+        try {
+            removed = db.compactMetadata(metadata.key(), watermark);
+        } catch (Exception e) {
+            logger.error("Failed to compact metadata for key={}", metadata.key(), e);
+            return 0;
+        }
+
+        int deleted = 0;
+        for (FileVersion v : removed) {
+            deleted += deletePhysicalFiles(v);
+        }
+        if (!removed.isEmpty()) {
+            logger.debug("GC compacted key={}: removed {} versions (watermark={})",
+                    metadata.key(), removed.size(), watermark);
+        }
+        return deleted;
+    }
+
+    private int deletePhysicalFiles(FileVersion version) {
+        int deleted = 0;
+        if (version instanceof RegularFileVersion r) {
+            if (tryDelete(r.location())) {
+                deleted++;
+            }
+        } else if (version instanceof MultipartFileVersion m) {
+            for (String chunk : m.chunks()) {
+                if (tryDelete(chunk)) {
+                    deleted++;
+                }
+            }
+        } else if (version instanceof TombstoneFileVersion) {
+            // No physical state — the tombstone marker itself was removed by
+            // metadata compaction.
+        }
+        return deleted;
+    }
+
+    private boolean tryDelete(String blobId) {
+        try {
+            storageNode.deleteBlobFile(blobId);
+            return true;
+        } catch (IOException e) {
+            logger.warn("Failed to delete blob file id={}", blobId, e);
+            return false;
+        } catch (IllegalArgumentException e) {
+            // Defensive: a malformed blobId stored long ago shouldn't crash GC
+            logger.warn("Refusing to delete blob with invalid id={}", blobId, e);
+            return false;
+        }
+    }
+}

--- a/storage-node/src/main/java/com/github/koop/storagenode/GossipMessage.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/GossipMessage.java
@@ -1,0 +1,55 @@
+package com.github.koop.storagenode;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Wire format for the GC gossip protocol.
+ *
+ * <p>Each storage node periodically broadcasts a {@code GossipMessage}
+ * advertising the lowest in-use sequence number per partition (see
+ * {@link ActiveSequenceTracker}). Peers compute the per-partition global
+ * minimum and use it as the safe-deletion watermark.
+ *
+ * <p>Binary layout:
+ * <pre>
+ *   int  nodeIdLen
+ *   byte nodeId[nodeIdLen]
+ *   int  numPartitions
+ *   { int partition, long seqNum } * numPartitions
+ * </pre>
+ */
+public record GossipMessage(String nodeId, Map<Integer, Long> lowestInUsePerPartition) {
+
+    public byte[] serialize() {
+        byte[] nodeBytes = nodeId.getBytes(StandardCharsets.UTF_8);
+        int size = 4 + nodeBytes.length + 4 + lowestInUsePerPartition.size() * (4 + 8);
+        ByteBuffer buf = ByteBuffer.allocate(size);
+        buf.putInt(nodeBytes.length);
+        buf.put(nodeBytes);
+        buf.putInt(lowestInUsePerPartition.size());
+        for (Map.Entry<Integer, Long> entry : lowestInUsePerPartition.entrySet()) {
+            buf.putInt(entry.getKey());
+            buf.putLong(entry.getValue());
+        }
+        return buf.array();
+    }
+
+    public static GossipMessage deserialize(byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        int nodeLen = buf.getInt();
+        byte[] nodeBytes = new byte[nodeLen];
+        buf.get(nodeBytes);
+        String nodeId = new String(nodeBytes, StandardCharsets.UTF_8);
+        int n = buf.getInt();
+        Map<Integer, Long> map = new HashMap<>(n);
+        for (int i = 0; i < n; i++) {
+            int partition = buf.getInt();
+            long seq = buf.getLong();
+            map.put(partition, seq);
+        }
+        return new GossipMessage(nodeId, map);
+    }
+}

--- a/storage-node/src/main/java/com/github/koop/storagenode/GossipService.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/GossipService.java
@@ -1,0 +1,152 @@
+package com.github.koop.storagenode;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.github.koop.common.pubsub.PubSubClient;
+
+/**
+ * Gossip-based watermarking service for the garbage-collection protocol.
+ *
+ * <p>The service runs on every storage node. Periodically each node publishes
+ * its own per-partition lowest-in-use sequence number (drawn from
+ * {@link ActiveSequenceTracker}) to a shared pub/sub topic. Every peer
+ * subscribes to the same topic, building up a {@code nodeId -> (partition ->
+ * seq)} table. The {@link #safeWatermark(int)} method returns the global
+ * minimum across all known peers (including self) for a partition — anything
+ * with a sequence number strictly less than that value can be safely garbage
+ * collected.
+ */
+public class GossipService {
+
+    private static final Logger logger = LogManager.getLogger(GossipService.class);
+
+    public static final String GOSSIP_TOPIC = "gc-gossip";
+    static final long DEFAULT_GOSSIP_INTERVAL_MS = 2_000;
+
+    private final String nodeId;
+    private final PubSubClient pubSub;
+    private final ActiveSequenceTracker tracker;
+    private final long gossipIntervalMs;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofVirtual().name("gc-gossip").factory());
+
+    /** Per-peer (including self) latest known per-partition lowest-in-use seq. */
+    private final Map<String, Map<Integer, Long>> peerWatermarks = new ConcurrentHashMap<>();
+    private volatile boolean running = false;
+
+    public GossipService(String nodeId, PubSubClient pubSub, ActiveSequenceTracker tracker) {
+        this(nodeId, pubSub, tracker, DEFAULT_GOSSIP_INTERVAL_MS);
+    }
+
+    GossipService(String nodeId, PubSubClient pubSub, ActiveSequenceTracker tracker, long gossipIntervalMs) {
+        this.nodeId = nodeId;
+        this.pubSub = pubSub;
+        this.tracker = tracker;
+        this.gossipIntervalMs = gossipIntervalMs;
+    }
+
+    public void start() {
+        if (running) {
+            throw new IllegalStateException("GossipService already running");
+        }
+        running = true;
+        pubSub.sub(GOSSIP_TOPIC, (topic, offset, bytes) -> onMessage(bytes));
+        long period = Math.max(gossipIntervalMs, 1);
+        scheduler.scheduleWithFixedDelay(this::publishOwnWatermark, period, period, TimeUnit.MILLISECONDS);
+        logger.info("GossipService started for nodeId={}, interval={}ms", nodeId, gossipIntervalMs);
+    }
+
+    public void stop() {
+        running = false;
+        scheduler.shutdownNow();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.warn("GossipService scheduler did not shut down within 5s");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Force a gossip publish immediately. Useful for tests. */
+    public void publishOwnWatermark() {
+        try {
+            Map<Integer, Long> snapshot = tracker.snapshotLowestInUse();
+            // Always update the local view first, even if no partitions are known
+            peerWatermarks.put(nodeId, new HashMap<>(snapshot));
+            if (snapshot.isEmpty()) {
+                return;
+            }
+            GossipMessage message = new GossipMessage(nodeId, snapshot);
+            pubSub.pub(GOSSIP_TOPIC, message.serialize());
+        } catch (Exception e) {
+            logger.error("Failed to publish gossip watermark", e);
+        }
+    }
+
+    private void onMessage(byte[] bytes) {
+        try {
+            GossipMessage message = GossipMessage.deserialize(bytes);
+            // Ignore our own gossip — we already updated the local view at publish time
+            if (message.nodeId().equals(nodeId)) {
+                return;
+            }
+            peerWatermarks.put(message.nodeId(), new HashMap<>(message.lowestInUsePerPartition()));
+        } catch (Exception e) {
+            logger.warn("Discarding malformed gossip message", e);
+        }
+    }
+
+    /**
+     * Returns the safe-deletion watermark for {@code partition}: the minimum
+     * lowest-in-use sequence across every node (including self) that has
+     * reported a value for this partition. Empty if no node has ever reported
+     * for this partition, in which case nothing in the partition is safe to
+     * delete.
+     *
+     * <p>Our own contribution is taken LIVE from {@link ActiveSequenceTracker}
+     * rather than from the (possibly stale) last-published value in
+     * {@link #peerWatermarks}. Otherwise, in the window between our gossip
+     * publishes, a seq we just processed locally wouldn't yet be reflected in
+     * our own entry and the worker could over-collect.
+     */
+    public OptionalLong safeWatermark(int partition) {
+        long min = Long.MAX_VALUE;
+        boolean anyReporter = false;
+
+        Long ownLive = tracker.snapshotLowestInUse().get(partition);
+        if (ownLive != null) {
+            anyReporter = true;
+            min = ownLive;
+        }
+
+        for (Map.Entry<String, Map<Integer, Long>> entry : peerWatermarks.entrySet()) {
+            if (entry.getKey().equals(nodeId)) {
+                continue; // self handled above via live tracker read
+            }
+            Long v = entry.getValue().get(partition);
+            if (v == null) {
+                continue;
+            }
+            anyReporter = true;
+            if (v < min) {
+                min = v;
+            }
+        }
+        return anyReporter ? OptionalLong.of(min) : OptionalLong.empty();
+    }
+
+    /** Test helper: number of distinct peers that have reported a watermark. */
+    int knownPeerCount() {
+        return peerWatermarks.size();
+    }
+}

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -48,6 +48,9 @@ public class StorageNodeServerV2 {
     private final RepairWorkerPool repairWorkerPool;
     private final RocksDbRepairQueue repairQueue;
     private final Database db;
+    private final ActiveSequenceTracker sequenceTracker;
+    private final GossipService gossipService;
+    private final GarbageCollectionWorker gcWorker;
 
     private Javalin app;
     private ErasureSetConfiguration currentEsConfig;
@@ -74,6 +77,10 @@ public class StorageNodeServerV2 {
         this.storageNode = new StorageNodeV2(db, dir, writeTracker);
         this.metadataClient = metadataClient;
         this.pubSubClient = pubSubClient;
+        this.sequenceTracker = new ActiveSequenceTracker();
+        String nodeIdentity = ip + ":" + port;
+        this.gossipService = new GossipService(nodeIdentity, pubSubClient, sequenceTracker);
+        this.gcWorker = new GarbageCollectionWorker(db, storageNode, gossipService, writeTracker);
     }
 
     public static void main(String[] args) {
@@ -286,62 +293,50 @@ public class StorageNodeServerV2 {
             }
             logger.debug("GET partition={} fullKey={} targetVersion={}", partition, fullKey, targetVersion);
 
-            Optional<StorageNodeV2.GetObjectResponse> dataOpt = storageNode.retrieve(fullKey, targetVersion);
+            // For explicit-version GETs we know up-front which seq we need to
+            // protect from concurrent garbage collection. Pin it BEFORE the
+            // retrieve so the window between metadata lookup and response
+            // streaming can't race with GC. For "latest" requests we don't
+            // know the seq until retrieve resolves it, but the latest version
+            // of a key is always at or above this node's high-water mark and
+            // therefore above the gossip safe-watermark, so GC won't touch it.
+            boolean explicitlyPinned = targetVersion != -1;
+            if (explicitlyPinned) {
+                sequenceTracker.beginGet(partition, targetVersion);
+            }
+            try {
+                Optional<StorageNodeV2.GetObjectResponse> dataOpt =
+                        storageNode.retrieve(fullKey, targetVersion);
 
-            if (dataOpt.isPresent()) {
-                StorageNodeV2.GetObjectResponse response = dataOpt.get();
+                if (dataOpt.isPresent()) {
+                    StorageNodeV2.GetObjectResponse response = dataOpt.get();
 
-                long responseSequenceNumber = switch (response) {
-                    case StorageNodeV2.FileObject fo -> fo.version().sequenceNumber();
-                    case StorageNodeV2.MultipartData md -> md.version().sequenceNumber();
-                    case StorageNodeV2.Tombstone t -> t.version().sequenceNumber();
-                };
+                    long responseSequenceNumber = switch (response) {
+                        case StorageNodeV2.FileObject fo -> fo.version().sequenceNumber();
+                        case StorageNodeV2.MultipartData md -> md.version().sequenceNumber();
+                        case StorageNodeV2.Tombstone t -> t.version().sequenceNumber();
+                    };
 
-                ctx.header("X-Koop-Version", String.valueOf(responseSequenceNumber));
-
-                if (response instanceof StorageNodeV2.FileObject fo) {
-                    ctx.header("X-Koop-Type", "BLOB");
-                    var fc = fo.data();
-                    ctx.status(200)
-                            .header("Content-Type", "application/octet-stream")
-                            .header("Content-Length", String.valueOf(fc.size()));
-
-                    var outputChannel = Channels.newChannel(ctx.res().getOutputStream());
-                    long size = fc.size();
-                    logger.debug("GET partition={} fullKey={} version={} streaming {} bytes", partition, fullKey,
-                            responseSequenceNumber, size);
-                    long position = 0L;
-                    while (position < size) {
-                        long transferred = fc.transferTo(position, size - position, outputChannel);
-                        if (transferred <= 0) {
-                            logger.warn(
-                                    "Zero-byte transfer when streaming file for partition={} fullKey={} at position={} of {} bytes",
-                                    partition, fullKey, position, size);
-                            break;
-                        }
-                        position += transferred;
+                    if (!explicitlyPinned) {
+                        sequenceTracker.beginGet(partition, responseSequenceNumber);
                     }
-                    fo.close();
-                    logger.debug("GET partition={} fullKey={} version={} streamed {} bytes", partition, fullKey,
-                            responseSequenceNumber, size);
-
-                } else if (response instanceof StorageNodeV2.MultipartData md) {
-                    ctx.header("X-Koop-Type", "MULTIPART");
-                    ctx.status(200)
-                       .header("Content-Type", "application/json")
-                       .json(md.version().chunks());
-                    logger.debug("GET partition={} fullKey={} version={} returned multipart chunks in body", partition, fullKey,
-                            responseSequenceNumber);
-
-                } else if (response instanceof StorageNodeV2.Tombstone) {
-                    ctx.header("X-Koop-Type", "TOMBSTONE");
-                    ctx.status(200).result("");
-                    logger.debug("GET partition={} fullKey={} version={} hit tombstone", partition, fullKey,
-                            responseSequenceNumber);
+                    try {
+                        serveGetResponse(ctx, partition, fullKey, responseSequenceNumber, response);
+                    } finally {
+                        if (!explicitlyPinned) {
+                            sequenceTracker.endGet(partition, responseSequenceNumber);
+                        }
+                    }
+                    return;
+                } else {
+                    ctx.status(404).result("NOT_FOUND");
+                    logger.debug("GET partition={} fullKey={} targetVersion={} not found",
+                            partition, fullKey, targetVersion);
                 }
-            } else {
-                ctx.status(404).result("NOT_FOUND");
-                logger.debug("GET partition={} fullKey={} targetVersion={} not found", partition, fullKey, targetVersion);
+            } finally {
+                if (explicitlyPinned) {
+                    sequenceTracker.endGet(partition, targetVersion);
+                }
             }
         } catch (Exception e) {
             logger.error("Error handling GET", e);
@@ -349,7 +344,57 @@ public class StorageNodeServerV2 {
         }
     }
 
+    private void serveGetResponse(Context ctx, int partition, String fullKey,
+                                  long responseSequenceNumber, StorageNodeV2.GetObjectResponse response)
+            throws Exception {
+        ctx.header("X-Koop-Version", String.valueOf(responseSequenceNumber));
+
+        if (response instanceof StorageNodeV2.FileObject fo) {
+            ctx.header("X-Koop-Type", "BLOB");
+            var fc = fo.data();
+            ctx.status(200)
+                    .header("Content-Type", "application/octet-stream")
+                    .header("Content-Length", String.valueOf(fc.size()));
+
+            var outputChannel = Channels.newChannel(ctx.res().getOutputStream());
+            long size = fc.size();
+            logger.debug("GET partition={} fullKey={} version={} streaming {} bytes", partition, fullKey,
+                    responseSequenceNumber, size);
+            long position = 0L;
+            while (position < size) {
+                long transferred = fc.transferTo(position, size - position, outputChannel);
+                if (transferred <= 0) {
+                    logger.warn(
+                            "Zero-byte transfer when streaming file for partition={} fullKey={} at position={} of {} bytes",
+                            partition, fullKey, position, size);
+                    break;
+                }
+                position += transferred;
+            }
+            fo.close();
+            logger.debug("GET partition={} fullKey={} version={} streamed {} bytes", partition, fullKey,
+                    responseSequenceNumber, size);
+
+        } else if (response instanceof StorageNodeV2.MultipartData md) {
+            ctx.header("X-Koop-Type", "MULTIPART");
+            ctx.status(200)
+               .header("Content-Type", "application/json")
+               .json(md.version().chunks());
+            logger.debug("GET partition={} fullKey={} version={} returned multipart chunks in body", partition, fullKey,
+                    responseSequenceNumber);
+
+        } else if (response instanceof StorageNodeV2.Tombstone) {
+            ctx.header("X-Koop-Type", "TOMBSTONE");
+            ctx.status(200).result("");
+            logger.debug("GET partition={} fullKey={} version={} hit tombstone", partition, fullKey,
+                    responseSequenceNumber);
+        }
+    }
+
     public void processSequencerMessage(int partition, Message message, long seqNumber) {
+        // Advance the per-partition high-water mark so the gossip layer can
+        // publish that this node is "up to" at least this sequence.
+        sequenceTracker.recordProcessedSeq(partition, seqNumber);
         try {
             String requestId = null;
             String callbackHost = message.sender().getHostString();
@@ -664,6 +709,8 @@ public class StorageNodeServerV2 {
 
     public void start() {
         repairWorkerPool.start();
+        gossipService.start();
+        gcWorker.start();
 
         app = Javalin.create(config -> {
             config.concurrency.useVirtualThreads = true;
@@ -708,6 +755,8 @@ public class StorageNodeServerV2 {
             app.stop();
         }
 
+        gcWorker.shutdown();
+        gossipService.stop();
         repairWorkerPool.shutdown();
 
         partitionExecutors.values().forEach(ExecutorService::shutdownNow);

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeV2.java
@@ -67,6 +67,24 @@ public class StorageNodeV2 {
         this.writeTracker = writeTracker;
     }
 
+    /**
+     * Resolves the on-disk path for a stored blob/chunk. Exposed for the
+     * garbage-collection worker so it can physically delete orphaned files.
+     */
+    Path resolveBlobPath(String id) {
+        return getObjectPath(id);
+    }
+
+    /**
+     * Physically deletes the blob file for {@code id} if it exists. Used by
+     * the {@link GarbageCollectionWorker} to clean up orphans referenced by
+     * versions that have fallen below the gossip safe-deletion watermark.
+     */
+    void deleteBlobFile(String id) throws java.io.IOException {
+        Path path = getObjectPath(id);
+        java.nio.file.Files.deleteIfExists(path);
+    }
+
     private Path getObjectPath(String id) {
         // Use the first three characters of the ID to create a sharded subdirectory
         // structure.

--- a/storage-node/src/main/java/com/github/koop/storagenode/db/Database.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/db/Database.java
@@ -194,6 +194,57 @@ public class Database implements AutoCloseable {
     }
 
     // -------------------------------------------------------------------------
+    // METADATA COMPACTION — for garbage collection
+    // -------------------------------------------------------------------------
+
+    /**
+     * Stream every metadata row in the local database. Used by the
+     * {@link com.github.koop.storagenode.GarbageCollectionWorker} to find
+     * stale {@link FileVersion} entries.
+     */
+    public Stream<Metadata> streamAllMetadata() throws Exception {
+        return strategy.streamAllMetadata();
+    }
+
+    /**
+     * Compacts the metadata row for {@code key} by removing every
+     * {@link FileVersion} whose sequence number is strictly less than
+     * {@code watermark}. If no versions survive compaction, the metadata row
+     * itself is deleted from the database.
+     *
+     * <p>Returns the list of {@link FileVersion}s that were removed so the
+     * caller can clean up the physical blob/chunk files they reference.
+     */
+    public List<FileVersion> compactMetadata(String key, long watermark) throws Exception {
+        try (StorageTransaction txn = strategy.beginTransaction()) {
+            Optional<Metadata> metadataOpt = txn.getMetadata(key);
+            if (metadataOpt.isEmpty()) {
+                return List.of();
+            }
+            Metadata metadata = metadataOpt.get();
+            List<FileVersion> kept = new ArrayList<>();
+            List<FileVersion> removed = new ArrayList<>();
+            for (FileVersion v : metadata.versions()) {
+                if (v.sequenceNumber() < watermark) {
+                    removed.add(v);
+                } else {
+                    kept.add(v);
+                }
+            }
+            if (removed.isEmpty()) {
+                return List.of();
+            }
+            if (kept.isEmpty()) {
+                txn.deleteMetadata(key);
+            } else {
+                txn.putMetadata(new Metadata(metadata.key(), metadata.partition(), kept));
+            }
+            txn.commit();
+            return removed;
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Lifecycle
     // -------------------------------------------------------------------------
 

--- a/storage-node/src/main/java/com/github/koop/storagenode/db/RocksDbStorageStrategy.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/db/RocksDbStorageStrategy.java
@@ -137,6 +137,18 @@ public class RocksDbStorageStrategy implements StorageStrategy {
         }).onClose(iterator::close).takeWhile(m -> m != null);
     }
 
+    @Override
+    public Stream<Metadata> streamAllMetadata() throws Exception {
+        RocksIterator iterator = txnDb.newIterator(metaHandle);
+        iterator.seekToFirst();
+        return Stream.generate(() -> {
+            if (!iterator.isValid()) return null;
+            Metadata m = Metadata.from(iterator.value());
+            iterator.next();
+            return m;
+        }).onClose(iterator::close).takeWhile(m -> m != null);
+    }
+
     // --- Table #3: Buckets ---
 
     @Override
@@ -199,6 +211,11 @@ public class RocksDbStorageStrategy implements StorageStrategy {
         @Override
         public void putMetadata(Metadata metadata) throws Exception {
             txn.put(metaHandle, metadata.key().getBytes(StandardCharsets.UTF_8), metadata.serialize());
+        }
+
+        @Override
+        public void deleteMetadata(String key) throws Exception {
+            txn.delete(metaHandle, key.getBytes(StandardCharsets.UTF_8));
         }
 
         @Override

--- a/storage-node/src/main/java/com/github/koop/storagenode/db/StorageStrategy.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/db/StorageStrategy.java
@@ -15,6 +15,7 @@ public interface StorageStrategy extends AutoCloseable {
     // --- Table #2: Metadata (includes version history) ---
     Optional<Metadata> getMetadata(String key) throws Exception;
     Stream<Metadata> streamMetadataWithPrefix(String prefix) throws Exception;
+    Stream<Metadata> streamAllMetadata() throws Exception;
 
     // --- Table #3: Buckets ---
     Optional<Bucket> getBucket(String key) throws Exception;

--- a/storage-node/src/main/java/com/github/koop/storagenode/db/StorageTransaction.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/db/StorageTransaction.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 public interface StorageTransaction extends AutoCloseable {
     Optional<Metadata> getMetadata(String key) throws Exception;
     void putMetadata(Metadata metadata) throws Exception;
+    void deleteMetadata(String key) throws Exception;
     void putLog(OpLog log) throws Exception;
     
     Optional<Bucket> getBucket(String key) throws Exception;

--- a/storage-node/src/test/java/com/github/koop/storagenode/ActiveSequenceTrackerTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/ActiveSequenceTrackerTest.java
@@ -1,0 +1,71 @@
+package com.github.koop.storagenode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class ActiveSequenceTrackerTest {
+
+    @Test
+    void emptyTrackerReportsNoPartitions() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        assertTrue(tracker.snapshotLowestInUse().isEmpty());
+    }
+
+    @Test
+    void highWaterMarkAdvancesMonotonically() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(1, 10L);
+        tracker.recordProcessedSeq(1, 30L);
+        tracker.recordProcessedSeq(1, 20L); // older, must be ignored
+
+        Map<Integer, Long> snap = tracker.snapshotLowestInUse();
+        assertEquals(30L, snap.get(1).longValue());
+    }
+
+    @Test
+    void activeGetDragsLowestInUseDown() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(1, 100L);
+        tracker.beginGet(1, 30L);
+        tracker.beginGet(1, 80L);
+
+        assertEquals(30L, tracker.snapshotLowestInUse().get(1).longValue());
+
+        tracker.endGet(1, 30L);
+        assertEquals(80L, tracker.snapshotLowestInUse().get(1).longValue());
+
+        tracker.endGet(1, 80L);
+        assertEquals(100L, tracker.snapshotLowestInUse().get(1).longValue());
+    }
+
+    @Test
+    void concurrentGetsOnSameSeqAreReferenceCounted() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(1, 100L);
+        tracker.beginGet(1, 5L);
+        tracker.beginGet(1, 5L); // second GET on the same version
+
+        tracker.endGet(1, 5L);
+        assertEquals(5L, tracker.snapshotLowestInUse().get(1).longValue(),
+                "Version must remain pinned while another GET is still serving it");
+
+        tracker.endGet(1, 5L);
+        assertEquals(100L, tracker.snapshotLowestInUse().get(1).longValue(),
+                "Pin must release once every GET on that seq has finished");
+    }
+
+    @Test
+    void perPartitionTracking() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(1, 50L);
+        tracker.recordProcessedSeq(2, 200L);
+        tracker.beginGet(2, 75L);
+
+        Map<Integer, Long> snap = tracker.snapshotLowestInUse();
+        assertEquals(50L, snap.get(1).longValue());
+        assertEquals(75L, snap.get(2).longValue());
+    }
+}

--- a/storage-node/src/test/java/com/github/koop/storagenode/GarbageCollectionWorkerTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/GarbageCollectionWorkerTest.java
@@ -1,0 +1,233 @@
+package com.github.koop.storagenode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.github.koop.common.pubsub.MemoryPubSub;
+import com.github.koop.common.pubsub.PubSubClient;
+import com.github.koop.storagenode.db.Database;
+import com.github.koop.storagenode.db.RocksDbStorageStrategy;
+
+class GarbageCollectionWorkerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Database database;
+    private StorageNodeV2 storageNode;
+    private ActiveSequenceTracker tracker;
+    private GossipService gossip;
+    private GarbageCollectionWorker worker;
+    private PubSubClient pubSub;
+    private WriteTracker writeTracker;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        database = new Database(new RocksDbStorageStrategy(
+                tempDir.resolve("rocksdb").toAbsolutePath().toString()));
+        writeTracker = new WriteTracker();
+        storageNode = new StorageNodeV2(database, tempDir, writeTracker);
+        tracker = new ActiveSequenceTracker();
+        pubSub = new PubSubClient(new MemoryPubSub());
+        pubSub.start();
+        gossip = new GossipService("test-node", pubSub, tracker, 60_000);
+        gossip.start();
+        worker = new GarbageCollectionWorker(database, storageNode, gossip, writeTracker, 60_000);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (worker != null) worker.shutdown();
+        if (gossip != null) gossip.stop();
+        if (database != null) database.close();
+    }
+
+    /** Materialize an empty file at the location the storage node would have written it. */
+    private void touchBlob(String blobId) throws Exception {
+        Path p = storageNode.resolveBlobPath(blobId);
+        Files.createDirectories(p.getParent());
+        Files.createFile(p);
+    }
+
+    private boolean blobExists(String blobId) {
+        return Files.exists(storageNode.resolveBlobPath(blobId));
+    }
+
+    @Test
+    void noWatermarkMeansNothingIsDeleted() throws Exception {
+        database.putItem("photos/cat", 1, 10L, "blob-10");
+        touchBlob("blob-10");
+
+        // No partition gossip yet → worker must be a no-op
+        int deleted = worker.runOnce();
+
+        assertEquals(0, deleted);
+        assertTrue(blobExists("blob-10"));
+        assertEquals(1, database.getItem("photos/cat").orElseThrow().versions().size());
+    }
+
+    @Test
+    void purgesStaleRegularVersionAndDeletesBlobFile() throws Exception {
+        database.putItem("photos/cat", 1, 5L, "blob-5");
+        database.putItem("photos/cat", 1, 20L, "blob-20");
+        touchBlob("blob-5");
+        touchBlob("blob-20");
+
+        tracker.recordProcessedSeq(1, 20L);
+        gossip.publishOwnWatermark();
+
+        int deleted = worker.runOnce();
+
+        assertEquals(1, deleted, "Exactly the stale blob file should be removed");
+        assertFalse(blobExists("blob-5"), "Stale blob file must be deleted from disk");
+        assertTrue(blobExists("blob-20"), "Live blob file must be preserved");
+
+        var versions = database.getItem("photos/cat").orElseThrow().versions();
+        assertEquals(1, versions.size());
+        assertEquals(20L, versions.get(0).sequenceNumber());
+    }
+
+    @Test
+    void preservesVersionsAtAndAboveWatermark() throws Exception {
+        database.putItem("k", 1, 10L, "blob-10");
+        database.putItem("k", 1, 20L, "blob-20");
+        touchBlob("blob-10");
+        touchBlob("blob-20");
+
+        tracker.recordProcessedSeq(1, 10L);
+        gossip.publishOwnWatermark();
+
+        worker.runOnce();
+
+        assertTrue(blobExists("blob-10"),
+                "Version equal to the watermark must be retained");
+        assertTrue(blobExists("blob-20"));
+        assertEquals(2, database.getItem("k").orElseThrow().versions().size());
+    }
+
+    @Test
+    void purgesTombstonedRowEntirelyWhenWatermarkPasses() throws Exception {
+        database.putItem("ephemeral", 1, 5L, "blob-eph");
+        database.deleteItem("ephemeral", 1, 6L);
+        touchBlob("blob-eph");
+
+        tracker.recordProcessedSeq(1, 100L);
+        gossip.publishOwnWatermark();
+
+        worker.runOnce();
+
+        assertFalse(blobExists("blob-eph"));
+        assertTrue(database.getItem("ephemeral").isEmpty(),
+                "Both the regular version and tombstone marker must be compacted away");
+    }
+
+    @Test
+    void purgesMultipartChunksOnDisk() throws Exception {
+        database.putMultipartItem("video", 1, 5L,
+                List.of("chunk-A", "chunk-B", "chunk-C"));
+        database.putItem("video", 1, 30L, "blob-30");
+        touchBlob("chunk-A");
+        touchBlob("chunk-B");
+        touchBlob("chunk-C");
+        touchBlob("blob-30");
+
+        tracker.recordProcessedSeq(1, 30L);
+        gossip.publishOwnWatermark();
+
+        int deleted = worker.runOnce();
+
+        assertEquals(3, deleted, "Each multipart chunk file should be removed");
+        assertFalse(blobExists("chunk-A"));
+        assertFalse(blobExists("chunk-B"));
+        assertFalse(blobExists("chunk-C"));
+        assertTrue(blobExists("blob-30"));
+    }
+
+    @Test
+    void activeGetPinsVersionAndPreventsItsCollection() throws Exception {
+        database.putItem("k", 1, 5L, "blob-5");
+        database.putItem("k", 1, 20L, "blob-20");
+        touchBlob("blob-5");
+        touchBlob("blob-20");
+
+        tracker.recordProcessedSeq(1, 20L);
+        // A GET is in flight serving version 5 — that must drag the watermark
+        // down and protect version 5 from collection.
+        tracker.beginGet(1, 5L);
+        gossip.publishOwnWatermark();
+
+        worker.runOnce();
+
+        assertTrue(blobExists("blob-5"),
+                "Active GET must protect the version it is currently serving");
+        assertTrue(blobExists("blob-20"));
+        assertEquals(2, database.getItem("k").orElseThrow().versions().size());
+
+        // Once the GET completes, the watermark advances and GC catches up.
+        tracker.endGet(1, 5L);
+        gossip.publishOwnWatermark();
+        worker.runOnce();
+
+        assertFalse(blobExists("blob-5"));
+        var versions = database.getItem("k").orElseThrow().versions();
+        assertEquals(1, versions.size());
+        assertEquals(20L, versions.get(0).sequenceNumber());
+    }
+
+    @Test
+    void respectsPerPartitionWatermarks() throws Exception {
+        // Two keys on different partitions; only partition 1 has a watermark.
+        database.putItem("k1", 1, 5L, "blob-p1-5");
+        database.putItem("k1", 1, 10L, "blob-p1-10");
+        database.putItem("k2", 2, 5L, "blob-p2-5");
+        database.putItem("k2", 2, 10L, "blob-p2-10");
+        touchBlob("blob-p1-5");
+        touchBlob("blob-p1-10");
+        touchBlob("blob-p2-5");
+        touchBlob("blob-p2-10");
+
+        tracker.recordProcessedSeq(1, 10L);
+        // partition 2 has no reported watermark — must be left untouched
+        gossip.publishOwnWatermark();
+
+        worker.runOnce();
+
+        assertFalse(blobExists("blob-p1-5"));
+        assertTrue(blobExists("blob-p1-10"));
+        assertTrue(blobExists("blob-p2-5"),
+                "Partition without gossip must not have versions collected");
+        assertTrue(blobExists("blob-p2-10"));
+    }
+
+    @Test
+    void skipsKeyWhileWriteIsInFlight() throws Exception {
+        database.putItem("k", 1, 5L, "blob-5");
+        touchBlob("blob-5");
+
+        tracker.recordProcessedSeq(1, 100L);
+        gossip.publishOwnWatermark();
+
+        writeTracker.begin("k");
+        try {
+            worker.runOnce();
+        } finally {
+            writeTracker.end("k");
+        }
+
+        assertTrue(blobExists("blob-5"),
+                "GC must defer collection while a write to the key is in flight");
+        assertEquals(1, database.getItem("k").orElseThrow().versions().size());
+
+        // Once the write completes, the next pass cleans up.
+        worker.runOnce();
+        assertFalse(blobExists("blob-5"));
+    }
+}

--- a/storage-node/src/test/java/com/github/koop/storagenode/GossipServiceTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/GossipServiceTest.java
@@ -1,0 +1,142 @@
+package com.github.koop.storagenode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.koop.common.pubsub.MemoryPubSub;
+import com.github.koop.common.pubsub.PubSubClient;
+
+class GossipServiceTest {
+
+    private PubSubClient pubSub;
+    private GossipService gossipA;
+    private GossipService gossipB;
+
+    @AfterEach
+    void tearDown() {
+        if (gossipA != null) gossipA.stop();
+        if (gossipB != null) gossipB.stop();
+    }
+
+    @Test
+    void gossipMessageRoundTrip() {
+        var original = new GossipMessage("node-1",
+                java.util.Map.of(1, 100L, 2, 200L, 7, 13L));
+        GossipMessage rt = GossipMessage.deserialize(original.serialize());
+        assertEquals("node-1", rt.nodeId());
+        assertEquals(java.util.Map.of(1, 100L, 2, 200L, 7, 13L), rt.lowestInUsePerPartition());
+    }
+
+    @Test
+    void safeWatermarkIsEmptyBeforeAnyGossip() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        var pubSub = new PubSubClient(new MemoryPubSub());
+        pubSub.start();
+        gossipA = new GossipService("node-a", pubSub, tracker, 1_000);
+        gossipA.start();
+
+        assertTrue(gossipA.safeWatermark(0).isEmpty());
+    }
+
+    @Test
+    void safeWatermarkReflectsOwnTrackerImmediatelyAfterPublish() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(0, 50L);
+
+        var pubSub = new PubSubClient(new MemoryPubSub());
+        pubSub.start();
+        gossipA = new GossipService("node-a", pubSub, tracker, 60_000);
+        gossipA.start();
+        gossipA.publishOwnWatermark();
+
+        OptionalLong wm = gossipA.safeWatermark(0);
+        assertTrue(wm.isPresent());
+        assertEquals(50L, wm.getAsLong());
+    }
+
+    @Test
+    void safeWatermarkIsGlobalMinimumAcrossPeers() throws Exception {
+        // Two services on a shared PubSubClient observe each other's messages
+        // through that client's per-topic listener fan-out.
+        pubSub = new PubSubClient(new MemoryPubSub());
+        pubSub.start();
+
+        ActiveSequenceTracker trackerA = new ActiveSequenceTracker();
+        ActiveSequenceTracker trackerB = new ActiveSequenceTracker();
+        trackerA.recordProcessedSeq(0, 100L);
+        trackerB.recordProcessedSeq(0, 50L);
+
+        gossipA = new GossipService("node-a", pubSub, trackerA, 60_000);
+        gossipB = new GossipService("node-b", pubSub, trackerB, 60_000);
+        gossipA.start();
+        gossipB.start();
+
+        gossipA.publishOwnWatermark();
+        gossipB.publishOwnWatermark();
+
+        awaitTrue(() -> gossipA.knownPeerCount() >= 2 && gossipB.knownPeerCount() >= 2, 2_000);
+
+        assertEquals(50L, gossipA.safeWatermark(0).getAsLong(),
+                "Node A must see the global minimum across peers");
+        assertEquals(50L, gossipB.safeWatermark(0).getAsLong(),
+                "Node B must see the global minimum across peers");
+    }
+
+    @Test
+    void safeWatermarkUsesLiveTrackerEvenWithoutRepublishing() {
+        // A node that has just processed a new seq but hasn't gossiped yet
+        // must NOT advertise a higher watermark than its current local state
+        // — otherwise the GC worker could over-collect during the gossip
+        // window.
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(0, 100L);
+
+        var pubSub = new PubSubClient(new MemoryPubSub());
+        pubSub.start();
+        gossipA = new GossipService("node-a", pubSub, tracker, 60_000);
+        gossipA.start();
+        gossipA.publishOwnWatermark(); // initial publish at hw=100
+
+        // Now an active GET begins for an old version. Without re-publishing,
+        // the local safe watermark must already reflect it.
+        tracker.beginGet(0, 5L);
+        assertEquals(5L, gossipA.safeWatermark(0).getAsLong(),
+                "safeWatermark must read live tracker state, not rely on the last gossip");
+    }
+
+    @Test
+    void activeGetPinsWatermarkBelowTheHighWaterMark() {
+        ActiveSequenceTracker tracker = new ActiveSequenceTracker();
+        tracker.recordProcessedSeq(0, 100L);
+        tracker.beginGet(0, 30L);
+
+        var pubSub = new PubSubClient(new MemoryPubSub());
+        pubSub.start();
+        gossipA = new GossipService("node-a", pubSub, tracker, 60_000);
+        gossipA.start();
+        gossipA.publishOwnWatermark();
+
+        assertEquals(30L, gossipA.safeWatermark(0).getAsLong(),
+                "An active GET below the high-water mark must drag the watermark down");
+
+        tracker.endGet(0, 30L);
+        gossipA.publishOwnWatermark();
+        assertEquals(100L, gossipA.safeWatermark(0).getAsLong(),
+                "Watermark returns to the high-water mark once the GET completes");
+    }
+
+    private static void awaitTrue(BooleanSupplier cond, long timeoutMs) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        while (System.nanoTime() < deadline) {
+            if (cond.getAsBoolean()) return;
+            Thread.sleep(20);
+        }
+        fail("condition not met within " + timeoutMs + "ms");
+    }
+}

--- a/storage-node/src/test/java/com/github/koop/storagenode/db/DatabaseCompactionTest.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/db/DatabaseCompactionTest.java
@@ -1,0 +1,98 @@
+package com.github.koop.storagenode.db;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DatabaseCompactionTest {
+
+    @TempDir
+    Path tempDir;
+    private Database database;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        database = new Database(new RocksDbStorageStrategy(tempDir.toAbsolutePath().toString()));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (database != null) database.close();
+    }
+
+    @Test
+    void compactRemovesVersionsStrictlyBelowWatermark() throws Exception {
+        database.putItem("k", 1, 5L, "blob-5");
+        database.putItem("k", 1, 10L, "blob-10");
+        database.putItem("k", 1, 15L, "blob-15");
+
+        List<FileVersion> removed = database.compactMetadata("k", 10L);
+
+        assertEquals(1, removed.size());
+        assertEquals(5L, removed.get(0).sequenceNumber());
+
+        var versions = database.getItem("k").orElseThrow().versions();
+        assertEquals(2, versions.size());
+        assertEquals(10L, versions.get(0).sequenceNumber());
+        assertEquals(15L, versions.get(1).sequenceNumber());
+    }
+
+    @Test
+    void compactPreservesVersionsAtTheWatermark() throws Exception {
+        database.putItem("k", 1, 10L, "blob-10");
+        database.putItem("k", 1, 11L, "blob-11");
+
+        List<FileVersion> removed = database.compactMetadata("k", 10L);
+
+        assertTrue(removed.isEmpty(), "Versions equal to the watermark must be retained");
+        assertEquals(2, database.getItem("k").orElseThrow().versions().size());
+    }
+
+    @Test
+    void compactDeletesRowWhenAllVersionsAreBelowWatermark() throws Exception {
+        database.putItem("k", 1, 5L, "blob-5");
+        database.deleteItem("k", 1, 6L); // tombstone
+
+        List<FileVersion> removed = database.compactMetadata("k", 100L);
+
+        assertEquals(2, removed.size());
+        assertTrue(database.getItem("k").isEmpty(),
+                "Metadata row must be deleted when no versions survive compaction");
+    }
+
+    @Test
+    void compactIsNoOpWhenWatermarkBelowAllVersions() throws Exception {
+        database.putItem("k", 1, 10L, "blob-10");
+        database.putItem("k", 1, 20L, "blob-20");
+
+        List<FileVersion> removed = database.compactMetadata("k", 10L);
+
+        assertTrue(removed.isEmpty());
+        assertEquals(2, database.getItem("k").orElseThrow().versions().size());
+    }
+
+    @Test
+    void compactIsNoOpForMissingKey() throws Exception {
+        List<FileVersion> removed = database.compactMetadata("does-not-exist", 100L);
+        assertTrue(removed.isEmpty());
+    }
+
+    @Test
+    void compactReturnsRemovedMultipartVersionWithChunks() throws Exception {
+        database.putMultipartItem("k", 1, 5L, List.of("c-a", "c-b", "c-c"));
+        database.putItem("k", 1, 20L, "blob-20");
+
+        List<FileVersion> removed = database.compactMetadata("k", 20L);
+
+        assertEquals(1, removed.size());
+        assertInstanceOf(MultipartFileVersion.class, removed.get(0));
+        assertEquals(List.of("c-a", "c-b", "c-c"),
+                ((MultipartFileVersion) removed.get(0)).chunks());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new distributed garbage collection (GC) protocol to the storage node, enabling safe deletion of obsolete file versions by coordinating watermarks across nodes using a gossip protocol. It adds core infrastructure for tracking in-use sequence numbers, a gossip-based watermarking service, and a background worker for physical GC, and integrates these components into the server. The most important changes are grouped below:

**Distributed Garbage Collection Infrastructure:**

* Added `ActiveSequenceTracker` to track the highest processed and actively served sequence numbers per partition, ensuring GET requests pin versions and prevent premature GC.
* Introduced `GossipService`, which periodically gossips each node's per-partition lowest-in-use sequence numbers and computes the global safe-deletion watermark for GC.
* Defined the `GossipMessage` wire format for efficient serialization/deserialization of per-partition watermarks between nodes.
* Implemented `GarbageCollectionWorker`, a background worker that scans metadata, consults the gossip-derived watermark, compacts metadata, and deletes obsolete physical files.

**Server Integration and GET Handling:**

* Integrated the new GC components (`ActiveSequenceTracker`, `GossipService`, `GarbageCollectionWorker`) into `StorageNodeServerV2`, initializing them at server startup. [[1]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968R51-R53) [[2]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968R80-R83)
* Updated GET request handling to pin the relevant sequence number in `ActiveSequenceTracker` during request processing, ensuring versions are protected from concurrent GC until the GET completes. [[1]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968L289-R309) [[2]](diffhunk://#diff-aa379c7eb53adaba22a3470cc9e5abb10c5cc1b5dd3948ec0497fdc6ff998968R320-R349)