### PR TITLE
handle immediate pipe death

### DIFF
--- a/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
+++ b/common-lib/src/main/java/com/github/koop/common/erasure/ErasureCoder.java
@@ -5,6 +5,9 @@ import com.backblaze.erasure.ReedSolomon;
 import java.io.*;
 import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +38,7 @@ public final class ErasureCoder {
 
     public static final int SHARD_SIZE = 1 << 20; // 1 MB per shard per stripe
     private static final Logger logger = LogManager.getLogger(ErasureCoder.class);
+    private static final Executor defaultExecutor = Executors.newVirtualThreadPerTaskExecutor();
 
     private ErasureCoder() {
     }
@@ -189,7 +193,7 @@ public final class ErasureCoder {
     // Sharding
     // -------------------------------------------------------------------------
 
-    public static InputStream[] shard(InputStream data, long length, int m, int n) throws IOException {
+public static InputStream[] shard(InputStream data, long length, int m, int n, Executor executor) throws IOException {
         if (data == null)
             throw new IllegalArgumentException("data is null");
         if (length < 0)
@@ -218,17 +222,27 @@ public final class ErasureCoder {
             pis[i] = pipes[i].in;
         }
 
-        Thread.startVirtualThread(() -> {
+        executor.execute(() -> {
             try {
+                // Initialize the dead array before the prefix write loop
+                boolean[] dead = new boolean[n];
+                
                 byte[] lenBytes = new byte[8];
                 writeLong(lenBytes, length);
-                for (int i = 0; i < n; i++)
-                    pos[i].write(lenBytes);
+                
+                // Wrap the prefix write in a try-catch to handle immediate connection drops
+                for (int i = 0; i < n; i++) {
+                    try {
+                        pos[i].write(lenBytes);
+                    } catch (IOException e) {
+                        dead[i] = true;
+                        logger.warn("Pipe for shard " + i + " died during length prefix write.");
+                    }
+                }
 
                 ReedSolomon rs = ReedSolomon.create(m, k);
                 byte[] stripeBuf = new byte[m * SHARD_SIZE];
                 long remaining = length;
-                boolean[] dead = new boolean[n];
 
                 while (remaining > 0) {
                     int want = (int) Math.min((long) stripeBuf.length, remaining);
@@ -260,21 +274,31 @@ public final class ErasureCoder {
                         }
                     }
                 }
-                for (int i = 0; i < n; i++)
-                    pos[i].flush();
+                
+                // Flush only the pipes that haven't been marked dead
+                for (int i = 0; i < n; i++) {
+                    if (!dead[i]) {
+                        pos[i].flush();
+                    }
+                }
             } catch (IOException e) {
                 logger.error("Error in erasure coding thread", e);
                 for (int i = 0; i < n; i++)
                     pipes[i].fail(e); // propagate to all consumers
             } finally {
-                for (OutputStream p : pos)
+                for (OutputStream p : pos) {
                     try {
                         p.close();
                     } catch (IOException ignored) {
                     }
+                }
             }
         });
         return pis;
+    }
+
+    public static InputStream[] shard(InputStream data, long length, int m, int n) throws IOException {
+        return shard(data, length, m, n, defaultExecutor);
     }
 
     // -------------------------------------------------------------------------

--- a/common-lib/src/test/java/com/github/koop/common/erasure/ErasureCoderTest.java
+++ b/common-lib/src/test/java/com/github/koop/common/erasure/ErasureCoderTest.java
@@ -9,9 +9,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
@@ -160,5 +162,69 @@ public class ErasureCoderTest {
         byte[] reconstructed = reconstructedStream.readAllBytes();
 
         assertArrayEquals(original, reconstructed, "Reconstructed large data payload does not match the original byte array.");
+    }
+
+   /**
+     * Tests resilience against immediate pipe closures deterministically. 
+     * By injecting a capturing Executor, the test prevents the producer thread 
+     * from starting until after the main thread has explicitly closed the pipes, 
+     * guaranteeing the prefix-write failure path is exercised.
+     */
+    @Test
+    public void testImmediatePipeClosureSurvives() throws Exception {
+        int m = 4;
+        int n = 6;
+        int size = 5 * 1024 * 1024; // 5 MB
+        byte[] original = new byte[size];
+        new Random(42).nextBytes(original);
+
+        // 1. Create an executor that merely captures the task instead of running it
+        AtomicReference<Runnable> producerTask = new AtomicReference<>();
+        Executor capturingExecutor = producerTask::set;
+
+        // 2. Call shard(). This creates the pipes, but the producer has NOT started.
+        InputStream[] shards = ErasureCoder.shard(new ByteArrayInputStream(original), size, m, n, capturingExecutor);
+        
+        // 3. Deterministically close two shards to simulate instantaneous connection refused.
+        shards[0].close();
+        shards[1].close();
+
+        byte[][] shardedData = new byte[n][];
+
+        ExecutorService exec = Executors.newFixedThreadPool(n);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            futures.add(exec.submit(() -> {
+                if (idx != 0 && idx != 1) {
+                    shardedData[idx] = shards[idx].readAllBytes();
+                }
+                return null;
+            }));
+        }
+
+        // 4. Now that the pipes are closed and consumers are waiting, release the producer.
+        Thread.startVirtualThread(producerTask.get());
+
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        exec.shutdown();
+
+        // Attempt reconstruction with the surviving streams (2, 3, 4, 5).
+        boolean[] present = new boolean[n];
+        InputStream[] reconstructInputs = new InputStream[n];
+        for (int i = 0; i < n; i++) {
+            if (shardedData[i] != null) {
+                present[i] = true;
+                reconstructInputs[i] = new ByteArrayInputStream(shardedData[i]);
+            }
+        }
+
+        // Note: If you also add Executor injection to reconstruct(), update this call accordingly.
+        InputStream reconstructedStream = ErasureCoder.reconstruct(reconstructInputs, present, m, n);
+        byte[] reconstructed = reconstructedStream.readAllBytes();
+
+        assertArrayEquals(original, reconstructed, "Data failed to reconstruct after immediate pipe closures.");
     }
 }

--- a/common-lib/src/test/java/com/github/koop/common/pubsub/KafakPubSubIT.java
+++ b/common-lib/src/test/java/com/github/koop/common/pubsub/KafakPubSubIT.java
@@ -19,9 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class KafkaPubSubTest {
+class KafakPubSubIT {
 
-    private static final Logger log = LogManager.getLogger(KafkaPubSubTest.class);
+    private static final Logger log = LogManager.getLogger(KafakPubSubIT.class);
 
     private ConfluentKafkaContainer kafka;
 


### PR DESCRIPTION
This pull request improves the resilience and testability of the `ErasureCoder` by making the sharding process more robust against immediate pipe closures, allowing injection of a custom `Executor`, and adding a deterministic test for this failure mode. It also includes a minor test class rename.

**Improvements to ErasureCoder resilience and flexibility:**

* The `shard` method in `ErasureCoder` now accepts an `Executor` parameter, allowing injection of custom executors for better control in tests and production. A default executor using virtual threads is provided for convenience. [[1]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aR8-R10) [[2]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aR41) [[3]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL192-R196) [[4]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL263-R303)
* The sharding logic now handles immediate pipe closures gracefully by tracking failed pipes during the prefix write phase and only flushing pipes that remain open. This prevents failures from propagating unnecessarily. [[1]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL221-L231) [[2]](diffhunk://#diff-08bf2ec4cd6b893c0c1862b1086d383e96523da29a4e71663857b1f2e02cc27aL263-R303)

**Testing improvements:**

* Added a new test, `testImmediatePipeClosureSurvives`, to `ErasureCoderTest` that deterministically exercises the code path for immediate pipe closure by injecting a capturing executor and closing pipes before the producer runs. This ensures the resilience logic is properly tested.

**Test class maintenance:**

* Renamed `KafkaPubSubTest` to `KafakPubSubIT` and updated logger references accordingly for consistency with integration test naming conventions.