### PR TITLE
Fix bucket check

### DIFF
--- a/docker-compose.k8s.yml
+++ b/docker-compose.k8s.yml
@@ -72,7 +72,7 @@ services:
       ETCD_URL: "http://etcd-0:2379"
       KAFKA_BOOTSTRAP_SERVERS: "kafka-0:9092,kafka-1:9092,kafka-2:9092"
       NODE_IP: "storage-node-set1-0"
-    depends_on: [etcd-0, kafka-0]
+    depends_on: [etcd-0, kafka-0, kafka-1, kafka-2]
   storage-node-set1-1: { <<: *sn_base, environment: { <<: *sn_env, NODE_IP: "storage-node-set1-1" } }
   storage-node-set1-2: { <<: *sn_base, environment: { <<: *sn_env, NODE_IP: "storage-node-set1-2" } }
   storage-node-set1-3: { <<: *sn_base, environment: { <<: *sn_env, NODE_IP: "storage-node-set1-3" } }
@@ -127,6 +127,9 @@ services:
     depends_on:
       - etcd-seeder
       - storage-node-set1-0
+      - kafka-0
+      - kafka-1
+      - kafka-2
   query-processor-2:
     <<: *qp_base
     ports: ["9002:8080"]

--- a/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
+++ b/query-processor/src/main/java/com/github/koop/queryprocessor/gateway/Main.java
@@ -165,6 +165,13 @@ public class Main {
         }
 
         try {
+            if (!storage.bucketExists(bucket)) {
+                ctx.status(404);
+                ctx.header("Content-Type", "application/xml");
+                ctx.result(buildS3ErrorXml("NoSuchBucket",
+                        "The specified bucket does not exist.", "/" + bucket));
+                return;
+            }
             List<ObjectSummary> objects = storage.listObjects(bucket, prefix, maxKeys);
             ctx.status(200);
             ctx.header("Content-Type", "application/xml");

--- a/query-processor/src/test/java/com/github/koop/queryprocessor/gateway/S3Test.java
+++ b/query-processor/src/test/java/com/github/koop/queryprocessor/gateway/S3Test.java
@@ -555,6 +555,7 @@ class S3Test {
     @Test
     @Order(23)
     void sdkListObjects_emptyBucket_returnsZeroContents() throws Exception {
+        when(mockStorage.bucketExists(BUCKET)).thenReturn(true);
         when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
                 .thenReturn(List.of());
 
@@ -574,6 +575,7 @@ class S3Test {
                 new ObjectSummary("file-a.txt", 100L, "2025-01-01T00:00:00Z"),
                 new ObjectSummary("file-b.txt", 200L, "2025-01-02T00:00:00Z")
         );
+        when(mockStorage.bucketExists(BUCKET)).thenReturn(true);
         when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
                 .thenReturn(summaries);
 
@@ -589,6 +591,7 @@ class S3Test {
     @Test
     @Order(25)
     void sdkListObjects_passesPrefix_toStorageService() throws Exception {
+        when(mockStorage.bucketExists(BUCKET)).thenReturn(true);
         when(mockStorage.listObjects(eq(BUCKET), eq("logs/"), anyInt()))
                 .thenReturn(List.of());
 
@@ -608,6 +611,7 @@ class S3Test {
         List<ObjectSummary> summaries = List.of(
                 new ObjectSummary("photo.jpg", 100L, "2025-01-01T00:00:00Z")
         );
+        when(mockStorage.bucketExists(BUCKET)).thenReturn(true);
         when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
                 .thenReturn(summaries);
 
@@ -629,6 +633,7 @@ class S3Test {
         List<ObjectSummary> summaries = List.of(
                 new ObjectSummary("a&b<c.txt", 50L, "2025-01-01T00:00:00Z")
         );
+        when(mockStorage.bucketExists(BUCKET)).thenReturn(true);
         when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
                 .thenReturn(summaries);
 
@@ -648,6 +653,7 @@ class S3Test {
     void sdkListObjects_maxKeysReflectedInResponse() throws Exception {
         // The XML builder hardcodes <MaxKeys>1000</MaxKeys> regardless of the
         // client's max-keys query parameter. The SDK should see the requested value.
+        when(mockStorage.bucketExists(BUCKET)).thenReturn(true);
         when(mockStorage.listObjects(eq(BUCKET), anyString(), anyInt()))
                 .thenReturn(List.of());
 
@@ -660,6 +666,23 @@ class S3Test {
 
         assertEquals(5, response.maxKeys(),
                 "MaxKeys in response should reflect the client's requested value, not hardcoded 1000");
+    }
+
+    @Test
+    @Order(284)
+    void sdkListObjects_bucketMissing_throwsNoSuchBucketException() throws Exception {
+        // The storage node deliberately does NOT 404 on a missing bucket during listing
+        // (bucket metadata only lives on the bucket's hash-partition, so most SNs would
+        // spuriously 404 even when the bucket exists). The gateway is the single layer
+        // that enforces NoSuchBucket semantics.
+        when(mockStorage.bucketExists("ghost-bucket")).thenReturn(false);
+
+        NoSuchBucketException ex = assertThrows(NoSuchBucketException.class, () ->
+                s3.listObjectsV2(ListObjectsV2Request.builder().bucket("ghost-bucket").build())
+        );
+
+        assertEquals(404, ex.statusCode());
+        verify(mockStorage, never()).listObjects(anyString(), anyString(), anyInt());
     }
 
     // ===================== MULTIPART UPLOAD =====================

--- a/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
+++ b/storage-node/src/main/java/com/github/koop/storagenode/StorageNodeServerV2.java
@@ -723,11 +723,11 @@ public class StorageNodeServerV2 {
                 return;
             }
 
-            if (!storageNode.bucketExists(bucket)) {
-                ctx.status(404);
-                return;
-            }
-
+            // Don't check bucketExists here: bucket metadata lives on the single partition
+            // the bucket name hashes to, while object metadata is distributed across every
+            // partition. A node serving this listing usually owns object partitions that
+            // are NOT the bucket's metadata partition, so the local check would 404 even
+            // though objects exist. Bucket existence is enforced at the gateway.
             String scanPrefix = bucket + "/";
             if (prefix != null && !prefix.isEmpty()) {
                 scanPrefix = bucket + "/" + prefix;

--- a/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
+++ b/storage-node/src/test/java/com/github/koop/storagenode/StorageNodeServerV2Test.java
@@ -585,6 +585,40 @@ class StorageNodeServerV2Test {
     }
 
     @Test
+    void testListObjects_succeedsWhenBucketMetadataLivesOnAnotherPartition() throws Exception {
+        // The bucket-creation message is published only to the partition that the bucket
+        // name hashes to. A storage node that owns a different partition (which still
+        // owns *objects* in that bucket) never sees CreateBucketMessage and so has no
+        // local record of the bucket. handleListObjects must NOT 404 in that case —
+        // otherwise listing fans out across partitions but only returns objects from the
+        // single SN that happens to own the bucket's metadata partition.
+        int objectPartition = 17;
+        String bucket = "cross-partition-bucket";
+        String key = "only-object.txt";
+        String fullKey = bucket + "/" + key;
+
+        // Note: NO CreateBucketMessage is processed. Only an object commit on this
+        // partition. This simulates an SN that owns an object partition but not the
+        // bucket's metadata partition.
+        http.send(HttpRequest.newBuilder()
+                        .uri(storeUriWithReq(objectPartition, fullKey, "req-xp-1"))
+                        .PUT(HttpRequest.BodyPublishers.ofString("data")).build(),
+                HttpResponse.BodyHandlers.ofString());
+        server.processSequencerMessage(objectPartition,
+                new Message.FileCommitMessage(bucket, key, "req-xp-1", getDummySender(), 1024L), 1300L);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(bucketUri(bucket))
+                .GET()
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode(),
+                "Listing must succeed even when this SN never saw the CreateBucketMessage");
+        assertTrue(resp.body().contains(fullKey),
+                "Listing should return the object stored on this partition, body=" + resp.body());
+    }
+
+    @Test
     void testListObjects_excludesDeletedObjects() throws Exception {
         int partition = 16;
         String bucket = "tombstone-list-bucket";


### PR DESCRIPTION
This pull request improves the handling of S3 bucket existence checks and object listing, ensuring correct behavior across distributed storage partitions. The main change is to enforce "NoSuchBucket" errors at the gateway layer, not at individual storage nodes, which fixes issues with distributed metadata. The PR also updates integration tests and docker-compose dependencies accordingly.

**Gateway and Storage Node Logic:**

* The gateway (`query-processor`) now checks if a bucket exists before listing objects, returning a proper S3 "NoSuchBucket" error if not. This ensures clients receive accurate errors, regardless of which storage node is queried.
* Storage nodes (`storage-node`) no longer check for bucket existence before listing objects, since object metadata is distributed and bucket metadata may be missing locally. This prevents false 404s and allows listings to succeed as long as objects exist on that node.

**Testing Improvements:**

* Added and updated tests in `S3Test.java` to mock `bucketExists()` appropriately and verify that missing buckets are handled at the gateway, not the storage node. A new test ensures the gateway throws the correct exception and does not call `listObjects()` on missing buckets. [[1]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R558) [[2]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R578) [[3]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R594) [[4]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R614) [[5]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R636) [[6]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R656) [[7]](diffhunk://#diff-55c8469db78733347435abadc633c04b893a6e7447f79326197ff4927d887b57R671-R687)
* Added a new test in `StorageNodeServerV2Test.java` to verify that listing objects succeeds even if the storage node has never seen the bucket's metadata, as long as it has relevant objects.

**Docker Compose Updates:**

* Updated `docker-compose.k8s.yml` to ensure that all query processors and storage nodes depend on all Kafka brokers, improving startup reliability in distributed setups. [[1]](diffhunk://#diff-f3e93a7a7df22bbd3d341093016d6662cd01c777bdef3665cc33f1adff72f9c0L75-R75) [[2]](diffhunk://#diff-f3e93a7a7df22bbd3d341093016d6662cd01c777bdef3665cc33f1adff72f9c0R130-R132)